### PR TITLE
ambiguous reference to overloaded definition

### DIFF
--- a/src/ogdl/ogdl.scala
+++ b/src/ogdl/ogdl.scala
@@ -80,7 +80,7 @@ object Ogdl {
     def parse(buffer: ByteBuffer): Ogdl = {
 
       def readString(mark: Int): String = {
-        val array = new Array[Byte](buffer.position - mark - 1)
+        val array = new Array[Byte](buffer.position() - mark - 1)
         buffer.position(mark)
         buffer.get(array)
         buffer.get()
@@ -93,7 +93,7 @@ object Ogdl {
           case '\t' =>
             readIndent(i + 1)
           case other =>
-            buffer.position(buffer.position - 1)
+            buffer.position(buffer.position() - 1)
             i
         }
 


### PR DESCRIPTION
when I try to compile the odgl module with java11 I get the following error:

```
[info] Compiling 1 Scala source to /Users/mpallmann/Projects/propensive/out/fury/ogdl/compile/dest/classes ...
[error] /Users/mpallmann/Projects/propensive/fury/src/ogdl/ogdl.scala:83:44: ambiguous reference to overloaded definition,
[error] both method position in class ByteBuffer of type (x$1: Int)java.nio.ByteBuffer
[error] and  method position in class Buffer of type ()Int
[error] match expected type ?
[error]         val array = new Array[Byte](buffer.position - mark - 1)
[error]                                            ^
[error] /Users/mpallmann/Projects/propensive/fury/src/ogdl/ogdl.scala:96:36: ambiguous reference to overloaded definition,
[error] both method position in class ByteBuffer of type (x$1: Int)java.nio.ByteBuffer
[error] and  method position in class Buffer of type ()Int
[error] match expected type ?
[error]             buffer.position(buffer.position - 1)
[error]                                    ^
[error] two errors found
1 targets failed
fury.ogdl.compile Compilation failed
```

adding the parentheses seems to fix that.