### PR TITLE
Make application modules work again

### DIFF
--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -182,7 +182,7 @@ object BuildCli {
       optModuleId  <- ~io(ModuleArg).opt.orElse(project.main)
       optModule    <- ~optModuleId.flatMap(project.modules.findBy(_).opt)
       module       <- optModule.ascribe(UnspecifiedModule())
-      schemaTree   <- schema.schemaTree()
+      schemaTree   <- schema.schemaTree(layout.pwd)
       universe     <- schemaTree.universe
       artifact     <- universe.artifact(module.ref(project))
       _            <- Bloop.server(cli)(io)
@@ -208,7 +208,7 @@ object BuildCli {
       optModuleId    <- ~io(ModuleArg).opt.orElse(moduleRef.map(_.moduleId)).orElse(project.main)
       optModule      <- ~optModuleId.flatMap(project.modules.findBy(_).opt)
       module         <- optModule.ascribe(UnspecifiedModule())
-      schemaTree     <- schema.schemaTree()
+      schemaTree     <- schema.schemaTree(layout.pwd)
       universe       <- schemaTree.universe
       artifact       <- universe.artifact(module.ref(project))
       artifacts      <- universe.transitiveDependencies(module.ref(project))(cli.shell, layout)
@@ -264,7 +264,7 @@ object BuildCli {
       optModuleId  <- ~io(ModuleArg).opt.orElse(project.main)
       optModule    <- ~optModuleId.flatMap(project.modules.findBy(_).opt)
       module       <- optModule.ascribe(UnspecifiedModule())
-      schemaTree   <- schema.schemaTree()
+      schemaTree   <- schema.schemaTree(layout.pwd)
       universe     <- schemaTree.universe
       artifact     <- universe.artifact(module.ref(project))
       _            <- universe.saveJars(cli)(io, module.ref(project), dir in layout.pwd)
@@ -288,7 +288,7 @@ object BuildCli {
       io           <- cli.io()
       module       <- optModule.ascribe(UnspecifiedModule())
       project      <- optProject.ascribe(UnspecifiedProject())
-      schemaTree   <- schema.schemaTree()
+      schemaTree   <- schema.schemaTree(layout.pwd)
       universe     <- schemaTree.universe
       artifact     <- universe.artifact(module.ref(project))
       classpath    <- universe.classpath(module.ref(project))
@@ -313,7 +313,7 @@ object BuildCli {
                       }
       module       <- optModule.ascribe(UnspecifiedModule())
       project      <- optProject.ascribe(UnspecifiedProject())
-      schemaTree   <- schema.schemaTree()
+      schemaTree   <- schema.schemaTree(layout.pwd)
       universe     <- schemaTree.universe
       artifact     <- universe.artifact(module.ref(project))
       compilation  <- universe.compilation(module.ref(project))

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -367,7 +367,7 @@ case class Schema(id: SchemaId,
                for {
                  repo     <- repos.findBy(ref.repo)
                  repoDir  <- repo.fullCheckout.get
-                 layer    <- Ogdl.read[Layer](Layout(layout.home, dir).furyConfig)
+                 layer    <- Ogdl.read[Layer](Layout(layout.home, repoDir).furyConfig)
                  resolved <- layer.schemas.findBy(ref.schema)
                  tree     <- resolved.schemaTree(repoDir)
                } yield tree

--- a/src/core/shell.scala
+++ b/src/core/shell.scala
@@ -25,6 +25,9 @@ case class Shell()(implicit env: Environment) {
 
   val environment: Environment = env
 
+  def runJava(classpath: List[String], main: String)(output: String => Unit): Running =
+    sh"java -cp ${classpath.mkString(":")} $main".async(output(_), output(_))
+
   object git {
 
     def setRemote(repo: Repo): Out =
@@ -97,6 +100,8 @@ case class Shell()(implicit env: Environment) {
     } yield output.split("\n").to[List]
   }
 
+
+
   object bloop {
     def start(): Running = {
       sh"sh -c 'launcher 1.2.1 > /dev/null'".async(_ => (), _ => ())
@@ -109,10 +114,8 @@ case class Shell()(implicit env: Environment) {
     def clean(name: String)(output: String => Unit): Running =
       sh"bloop clean --config-dir .fury/bloop $name".async(output(_), output(_))
 
-    def compile(name: String, run: Boolean)(output: String => Unit): Running = {
-      val action = if(run) "run" else "compile"
-      sh"bloop $action --config-dir .fury/bloop $name".async(output(_), output(_))
-    }
+    def compile(name: String)(output: String => Unit): Running =
+      sh"bloop compile $name --config-dir .fury/bloop".async(output(_), output(_))
 
     def startServer(): Running =
       sh"bloop server".async(_ => (), _ => ())


### PR DESCRIPTION
This reinstates the functionality that application modules should be run after they've been compiled. Previously this would be done by calling `bloop run`, though this command appears to have stopped working, for reasons that aren't clear.

The code which implements this is a bit ugly. I hope that `bloop run` will be fixed so that it can be removed, but it appears, at least, to work currently. We can improve it later.