### PR TITLE
Include a version number with the Layer

### DIFF
--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -138,7 +138,7 @@ object BuildCli {
       cli <- cli.hint(ForceArg)
       io <- cli.io()
       force <- ~io(ForceArg).toOption.isDefined
-      layer <- ~Layer.empty()
+      layer <- ~Layer()
       _ <- ~io.println("Initializing new build directory: ./.fury")
       _ <- layout.furyConfig.mkParents()
       _ <- ~io.save(layer, layout.furyConfig)

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -494,8 +494,9 @@ object Alias {
 case class Alias(cmd: AliasCmd, description: String, schema: Option[SchemaId], module: ModuleRef)
 
 case class Layer(
-    schemas: SortedSet[Schema],
-    main: SchemaId,
+    version: Int = Layer.CurrentVersion,
+    schemas: SortedSet[Schema] = TreeSet(Schema(SchemaId.default)),
+    main: SchemaId = SchemaId.default,
     aliases: SortedSet[Alias] = TreeSet()) { layer =>
 
   def mainSchema: Outcome[Schema] = schemas.findBy(main)
@@ -509,10 +510,10 @@ case class Layer(
 }
 
 object Layer {
-  def empty() = Layer(SortedSet(Schema(SchemaId.default)), SchemaId.default)
+  val CurrentVersion = 1
 
   def read(file: Path)(implicit layout: Layout): Outcome[Layer] =
-    Success(Ogdl.read[Layer](file).toOption.getOrElse(Layer.empty()))
+    Success(Ogdl.read[Layer](file).toOption.getOrElse(Layer()))
 }
 
 object ModuleRef {

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -140,7 +140,7 @@ case class Module(
   def sharedSources: SortedSet[SharedSource] = sources.collect {
     case src: SharedSource => src
   }
-  
+
   def localSources: SortedSet[Path] = sources.collect { case src: LocalSource => src.path }
 }
 
@@ -792,6 +792,7 @@ case class Artifact(
     intransitive: Boolean,
     localSources: List[Path],
     sharedSources: List[Path]) {
+
   def hash: Digest =
     (kind, main, checkouts, binaries, dependencies, compiler, params).digest[Md5]
 


### PR DESCRIPTION
This number should be incremented every time there's a release with a model that's different from the previous release. Hopefully, when reading the layer, the version number can be read (after parsing, but before case-class construction) and dynamic transformations can take place on the OGDL tree which upgrade the file format to the current version, before it's interpreted as case classes.