### PR TITLE
Provide suggestions for remote tags and branches when adding a repo

### DIFF
--- a/src/core/cli.scala
+++ b/src/core/cli.scala
@@ -161,7 +161,7 @@ case class Cli[+Hinted <: CliParam[_]](
   def defaultTo(defaultCmd: Cmd) = copy(args = args + defaultCmd.cmd)
 
   def abort(msg: UserMsg): ExitStatus = {
-    write(msg)
+    if(!completion) write(msg)
     Abort
   }
 

--- a/src/repo/repo.scala
+++ b/src/repo/repo.scala
@@ -110,7 +110,10 @@ object RepoCli {
       cli <- cli.hint(ImportArg2)
       projectNameOpt <- ~cli.peek(RepoArg).map(fury.Repo.fromString).flatMap(_.projectName.toOption)
       cli <- cli.hint(RepoNameArg, projectNameOpt)
-      cli <- cli.hint(VersionArg)
+      remoteOpt <- ~cli.peek(RepoArg)
+      repoOpt <- ~remoteOpt.map(fury.Repo.fromString(_))
+      versions <- repoOpt.map { repo => cli.shell.git.lsRemote(repo.url) }.to[List].sequence.map(_.flatten).recover { case e => Nil }
+      cli <- cli.hint(VersionArg, versions)
       io <- cli.io()
       optImport <- ~io(ImportArg2).toOption
       optSchemaArg <- ~io(SchemaArg).toOption


### PR DESCRIPTION
This provides tab-completion for the -V parameter to the `fury repo add`
command.