### PR TITLE
Include the repository name in the list of imports

### DIFF
--- a/src/core/tables.scala
+++ b/src/core/tables.scala
@@ -19,6 +19,7 @@ import escritoire._
 import kaleidoscope._
 
 import scala.collection.immutable.SortedSet
+import scala.util._
 
 case class Tables(config: Config) {
 
@@ -118,6 +119,30 @@ case class Tables(config: Config) {
       Heading("GROUP", _.group),
       Heading("ARTIFACT", _.artifact),
       Heading("VERSION", _.version)
+  )
+
+  def imports(current: Option[SchemaId]): Tabulation[(SchemaRef, Try[Schema])] = Tabulation(
+      Heading("", s => Some(s._1.schema.key) == current),
+      Heading("REPO", _._1.repo),
+      Heading("SCHEMA", _._1.schema),
+      Heading(
+          "PROJECTS",
+          s =>
+            s._2.toOption.map { s =>
+              bar(s.projects.size)
+            }.getOrElse(msg"-")),
+      Heading(
+          "REPOS",
+          s =>
+            s._2.toOption.map { s =>
+              bar(s.sourceRepoIds.size)
+            }.getOrElse(msg"-")),
+      Heading(
+          "IMPORTS",
+          s =>
+            s._2.toOption.map { s =>
+              bar(s.imports.size)
+            }.getOrElse(msg"-"))
   )
 
   def schemas(current: Option[SchemaId]): Tabulation[Schema] = Tabulation(

--- a/src/imports/imports.scala
+++ b/src/imports/imports.scala
@@ -77,8 +77,11 @@ object ImportCli {
       cli       <- cli.hint(RawArg)
       io        <- cli.io()
       raw       <- ~io(RawArg).isSuccess
-      rows      <- schema.importedSchemas(layout, cli.shell)
-      table     <- ~Tables(config).show(Tables(config).schemas(Some(layer.main)), cols, rows, raw)(_.id)
+      rows <- ~schema.imports.map { i =>
+               (i, i.resolve(schema)(layout, cli.shell))
+             }
+      table <- ~Tables(config).show(Tables(config).imports(Some(layer.main)), cols, rows, raw)(
+                  _._1.schema.key)
       _ <- ~(if (!raw)
                io.println(Tables(config).contextString(layout.pwd, layer.showSchema, schema))
              else io)


### PR DESCRIPTION
This was previously excluded because it was lost once the imports were resolved to schemas.