### PR TITLE
Git pull working

### DIFF
--- a/src/menu/menu.scala
+++ b/src/menu/menu.scala
@@ -45,7 +45,7 @@ object FuryMenu {
             Action('bloop, msg"clean bloop artifacts", CleanCli.cleanBloop),
             Action('classes, msg"clean compiled classes", CleanCli.cleanClasses),
             Action('repositories, msg"clean repositories", CleanCli.cleanRepos),
-            Action('sources, msg"clean checked out sources", CleanCli.cleanSources),
+            Action('sources, msg"clean checked out sources", CleanCli.cleanSources)
         ),
         Action('completion, msg"ZSH completions", Cli.asCompletion(menu(aliases)), false),
         Menu('config, msg"change system configuration options", ConfigCli.context, 'set)(

--- a/src/repo/repo.scala
+++ b/src/repo/repo.scala
@@ -124,12 +124,10 @@ object RepoCli {
       dir          <- ~io(DirArg).toOption
       version      <- ~io(VersionArg).toOption.getOrElse(RefSpec.master)
       repo         <- ~remote.map(fury.Repo.fromString(_))
-      suggested <- (repo.flatMap(_.projectName.toOption): Option[RepoId])
-                    .orElse(dir.map { d =>
-                      RepoId(d.value.split("/").last)
-                    })
-                    .ascribe(exoskeleton.MissingArg("repo"))
-      nameArg <- ~io(RepoNameArg).toOption.getOrElse(suggested)
+      suggested <- ~(repo.flatMap(_.projectName.toOption): Option[RepoId]).orElse(dir.map { d =>
+                    RepoId(d.value.split("/").last)
+                  })
+      nameArg <- io(RepoNameArg).toOption.orElse(suggested).ascribe(exoskeleton.MissingArg("name"))
       sourceRepo <- repo
                      .map(SourceRepo(nameArg, _, version, dir))
                      .orElse(dir.map { d =>

--- a/src/repo/repo.scala
+++ b/src/repo/repo.scala
@@ -70,11 +70,16 @@ object RepoCli {
       dir       <- io(DirArg)
       retry     <- ~io(RetryArg).isSuccess
       bareRepo  <- repo.repo.fetch(layout, cli.shell)
-      _         <- ~cli.shell.git.sparseCheckout(bareRepo, dir, List(), repo.refSpec.id)
-      newRepo   <- ~repo.copy(local = Some(dir))
-      lens      <- ~Lenses.layer.repos(schema.id)
-      layer     <- ~(lens.modify(layer)(_ - repo + newRepo))
-      _         <- ~io.save(layer, layout.furyConfig)
+      _ <- ~cli.shell.git.sparseCheckout(
+              bareRepo,
+              dir,
+              List(),
+              refSpec = repo.refSpec.id,
+              commit = repo.currentCheckout.id)
+      newRepo <- ~repo.copy(local = Some(dir))
+      lens    <- ~Lenses.layer.repos(schema.id)
+      layer   <- ~(lens.modify(layer)(_ - repo + newRepo))
+      _       <- ~io.save(layer, layout.furyConfig)
     } yield io.await()
   }
 
@@ -95,6 +100,27 @@ object RepoCli {
       repos <- optRepos.map(schema.repo(_)(layout, cli.shell)).sequence
       msgs  <- repos.map(_.repo.update()(cli.shell, layout)).sequence
       _     <- ~msgs.foreach(io.println(_))
+      lens  <- ~Lenses.layer.repos(schema.id)
+      newRepos <- repos
+                   .map(
+                       repo =>
+                         for {
+                           commit <- repo.repo
+                                      .getCommitFromTag(layout, cli.shell, repo.refSpec)
+                                      .map(CheckoutId(_))
+                           newRepo = repo.copy(currentCheckout = commit)
+                         } yield (newRepo, repo)
+                   )
+                   .sequence
+      newLayer = newRepos.foldLeft(layer) { (layer, repoDiff) =>
+        repoDiff match { case (newRepo, oldRepo) => lens.modify(layer)(_ - oldRepo + newRepo) }
+      }
+      _ <- ~io.save(newLayer, layout.furyConfig)
+      _ <- ~newRepos.foreach {
+            case (newRepo, _) =>
+              io.println(
+                  s"Repo [${newRepo.id.key}] checked out to commit [${newRepo.currentCheckout.id}]")
+          }
     } yield io.await()
   }
 
@@ -128,21 +154,25 @@ object RepoCli {
                     RepoId(d.value.split("/").last)
                   })
       nameArg <- io(RepoNameArg).toOption.orElse(suggested).ascribe(exoskeleton.MissingArg("name"))
+      _       <- repo.map(_.fetch(layout, cli.shell)).ascribe(exoskeleton.MissingArg("repo"))
+      tag <- repo
+              .map(_.getCommitFromTag(layout, cli.shell, version))
+              .getOrElse(Failure(exoskeleton.MissingArg("name")))
       sourceRepo <- repo
-                     .map(SourceRepo(nameArg, _, version, dir))
+                     .map(SourceRepo(nameArg, _, version, CheckoutId(tag), dir))
                      .orElse(dir.map { d =>
-                       SourceRepo(nameArg, fury.Repo(""), RefSpec.master, Some(d))
+                       SourceRepo(nameArg, fury.Repo(""), RefSpec.master, CheckoutId(tag), Some(d))
                      })
                      .ascribe(exoskeleton.MissingArg("repo"))
+
       lens         <- ~Lenses.layer.repos(schema.id)
-      layer        <- ~(lens.modify(layer)(_ + sourceRepo))
       optImportRef <- ~optImport.map(SchemaRef(sourceRepo.id, _))
       layer <- optImportRef.map { importRef =>
                 Lenses.updateSchemas(optSchemaArg, layer, true)(Lenses.layer.imports(_))(
                     _.modify(_)(_ :+ importRef))
               }.getOrElse(~layer)
-      _ <- sourceRepo.repo.fetch(layout, cli.shell)
-      _ <- ~io.save(layer, layout.furyConfig)
+      layer <- ~(lens.modify(layer)(_ + sourceRepo))
+      _     <- ~io.save(layer, layout.furyConfig)
     } yield io.await()
   }
 


### PR DESCRIPTION
1. Reliable branch tracking in repos

Change fury repo pull behavior in that way, it keeps both the refspec
and the commit hash in fury config file. This means that the code
contributor can run `fury repo pull` and push new layer.fury and
another user who downloads it will not get the code from refspec
(that might be updated since that time) but from the exact commit hash.

2. Add possiblitiy to `fury add repo -r <local path>`

Required for testing

Task #62