### PR TITLE
Automatic migration of layer.fury files

### DIFF
--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -53,7 +53,7 @@ object AliasCli {
     for {
       layout <- cli.layout
       config <- Config.read()(cli.env, layout)
-      layer  <- Layer.read(layout.furyConfig)(layout)
+      layer  <- Layer.read(layout.furyConfig)(layout, cli.shell)
     } yield new MenuContext(cli, layout, config, layer)
 
   def list(ctx: MenuContext) = {
@@ -126,7 +126,7 @@ object BuildCli {
     for {
       layout <- cli.layout
       config <- Config.read()(cli.env, layout)
-      layer  <- Layer.read(layout.furyConfig)(layout)
+      layer  <- Layer.read(layout.furyConfig)(layout, cli.shell)
     } yield new MenuContext(cli, layout, config, layer)
 
   def notImplemented(cli: Cli[CliParam[_]]): Outcome[ExitStatus] = Success(Abort)
@@ -225,7 +225,7 @@ object BuildCli {
     for {
       layout <- cli.layout
       config <- Config.read()(cli.env, layout)
-      layer  <- ~Layer.read(layout.furyConfig)(layout).toOption
+      layer  <- ~Layer.read(layout.furyConfig)(layout, cli.shell).toOption
       msg <- layer
               .map(getPrompt(_, config.theme))
               .getOrElse(Success(Prompt.empty(config)(config.theme)))
@@ -327,7 +327,7 @@ object LayerCli {
     for {
       layout    <- cli.layout
       config    <- Config.read()(cli.env, layout)
-      layer     <- Layer.read(layout.furyConfig)(layout)
+      layer     <- Layer.read(layout.furyConfig)(layout, cli.shell)
       cli       <- cli.hint(SchemaArg, layer.schemas)
       schemaArg <- ~cli.peek(SchemaArg).getOrElse(layer.main)
       schema    <- layer.schemas.findBy(schemaArg)

--- a/src/core/config.scala
+++ b/src/core/config.scala
@@ -26,7 +26,7 @@ import scala.util._
 object Config {
 
   def read()(implicit env: Environment, layout: Layout): Outcome[Config] =
-    Success(Ogdl.read[Config](layout.userConfig).toOption.getOrElse(Config()))
+    Success(Ogdl.read[Config](layout.userConfig, identity(_)).toOption.getOrElse(Config()))
 }
 
 case class Config(showContext: Boolean = true, theme: Theme = Theme.Basic, undoBuffer: Int = 5)

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -544,7 +544,7 @@ object Layer {
                   repos = schema.repos.map { repo =>
                     //io.println(s"Checking commit hash for ${repo.repo()}")
                     val commit = shell.git.lsRemoteRefSpec(repo.repo(), repo.refSpec()).toOption.get
-                    repo.set(commit = Ogdl(CheckoutId(commit)), track = repo.refSpec)
+                    repo.set(commit = Ogdl(Commit(commit)), track = repo.refSpec)
                   }
               )
             },
@@ -647,7 +647,7 @@ object Repo {
 case class Checkout(
     repo: Repo,
     local: Boolean,
-    commit: CheckoutId,
+    commit: Commit,
     refSpec: RefSpec,
     sources: List[Path]) {
 
@@ -686,12 +686,7 @@ object SourceRepo {
   implicit def diff: Diff[SourceRepo]             = Diff.gen[SourceRepo]
 }
 
-case class SourceRepo(
-    id: RepoId,
-    repo: Repo,
-    track: RefSpec,
-    commit: CheckoutId,
-    local: Option[Path]) { // TODO: change Option[String] to RefSpec
+case class SourceRepo(id: RepoId, repo: Repo, track: RefSpec, commit: Commit, local: Option[Path]) { // TODO: change Option[String] to RefSpec
 
   def listFiles(implicit layout: Layout, shell: Shell): Outcome[List[Path]] =
     for {
@@ -964,11 +959,11 @@ object RefSpec {
 }
 case class RefSpec(id: String)
 
-object CheckoutId {
-  implicit val stringShow: StringShow[CheckoutId] = _.id
-  implicit val msgShow: MsgShow[CheckoutId]       = r => UserMsg(_.version(r.id.take(7)))
+object Commit {
+  implicit val stringShow: StringShow[Commit] = _.id
+  implicit val msgShow: MsgShow[Commit]       = r => UserMsg(_.version(r.id.take(7)))
 }
-case class CheckoutId(id: String)
+case class Commit(id: String)
 
 object Source {
   implicit val stringShow: StringShow[Source] = _.description

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -537,12 +537,12 @@ object Layer {
     (try ogdl.version().toInt
     catch { case e: Exception => 1 }) match {
       case 1 =>
-        println("Migrating layer.fury from file format v1")
+        //io.println("Migrating layer.fury from file format v1")
         ogdl.set(
             schemas = ogdl.schemas.map { schema =>
               schema.set(
                   repos = schema.repos.map { repo =>
-                    println(s"Checking commit hash for ${repo.repo()}")
+                    //io.println(s"Checking commit hash for ${repo.repo()}")
                     val commit = shell.git.lsRemoteRefSpec(repo.repo(), repo.refSpec()).toOption.get
                     repo.set(commit = Ogdl(CheckoutId(commit)), track = repo.refSpec)
                   }
@@ -966,7 +966,7 @@ case class RefSpec(id: String)
 
 object CheckoutId {
   implicit val stringShow: StringShow[CheckoutId] = _.id
-  implicit val msgShow: MsgShow[CheckoutId]       = r => UserMsg(_.version(r.id))
+  implicit val msgShow: MsgShow[CheckoutId]       = r => UserMsg(_.version(r.id.take(7)))
 }
 case class CheckoutId(id: String)
 

--- a/src/core/shell.scala
+++ b/src/core/shell.scala
@@ -97,6 +97,11 @@ case class Shell()(implicit env: Environment) {
             .exec[Outcome[String]]
             .map(_.split("\n").to[List].map(_.split("/").last)))
 
+    def lsRemoteRefSpec(url: String, refSpec: String): Outcome[String] =
+      Cached.lsRemoteRefSpec.getOrElseUpdate(
+          (url, refSpec),
+          sh"git ls-remote $url $refSpec".exec[Outcome[String]].map(_.take(40)))
+
     def checkout(dir: Path, commit: String): Outcome[String] =
       sh"git -C ${dir.value} checkout $commit".exec[Outcome[String]].map { out =>
         (dir / ".done").touch()
@@ -213,5 +218,6 @@ case class Shell()(implicit env: Environment) {
 }
 
 object Cached {
-  val lsRemote: HashMap[String, Outcome[List[String]]] = new HashMap()
+  val lsRemote: HashMap[String, Outcome[List[String]]]            = new HashMap()
+  val lsRemoteRefSpec: HashMap[(String, String), Outcome[String]] = new HashMap()
 }

--- a/src/core/tables.scala
+++ b/src/core/tables.scala
@@ -164,8 +164,8 @@ case class Tables(config: Config) {
   def repositories(implicit layout: Layout, shell: Shell): Tabulation[SourceRepo] = Tabulation(
       Heading("REPO", _.id),
       Heading("REMOTE", _.repo),
-      Heading("REFSPEC", _.refSpec),
-      //Heading("COMMIT", _.current.opt),
+      Heading("TRACK", _.track),
+      Heading("COMMIT", _.commit),
       Heading("LOCAL", _.local)
   )
 

--- a/src/dependency/dependency.scala
+++ b/src/dependency/dependency.scala
@@ -42,7 +42,7 @@ object DependencyCli {
     for {
       layout    <- cli.layout
       config    <- Config.read()(cli.env, layout)
-      layer     <- Layer.read(layout.furyConfig)(layout)
+      layer     <- Layer.read(layout.furyConfig)(layout, cli.shell)
       cli       <- cli.hint(SchemaArg, layer.schemas)
       schemaArg <- ~cli.peek(SchemaArg)
       schema    <- ~layer.schemas.findBy(schemaArg.getOrElse(layer.main)).toOption

--- a/src/imports/imports.scala
+++ b/src/imports/imports.scala
@@ -30,7 +30,7 @@ object ImportCli {
     for {
       layout <- cli.layout
       config <- fury.Config.read()(cli.env, layout)
-      layer  <- Layer.read(layout.furyConfig)(layout)
+      layer  <- Layer.read(layout.furyConfig)(layout, cli.shell)
     } yield Context(cli, layout, config, layer)
 
   def add(ctx: Context) = {

--- a/src/menu/main.scala
+++ b/src/menu/main.scala
@@ -28,7 +28,7 @@ object Main {
     val layer = for {
       layout <- cli.layout
       config <- fury.Config.read()(cli.env, layout)
-      layer  <- Layer.read(layout.furyConfig)(layout)
+      layer  <- Layer.read(layout.furyConfig)(layout, cli.shell)
     } yield layer
 
     val actions = layer.toOption

--- a/src/module/module.scala
+++ b/src/module/module.scala
@@ -42,7 +42,7 @@ object ModuleCli {
     for {
       layout    <- cli.layout
       config    <- Config.read()(cli.env, layout)
-      layer     <- Layer.read(layout.furyConfig)(layout)
+      layer     <- Layer.read(layout.furyConfig)(layout, cli.shell)
       cli       <- cli.hint(SchemaArg, layer.schemas)
       schemaArg <- ~cli.peek(SchemaArg)
       schema    <- ~layer.schemas.findBy(schemaArg.getOrElse(layer.main)).toOption

--- a/src/ogdl/fury/ogdl/Ogdl.scala
+++ b/src/ogdl/fury/ogdl/Ogdl.scala
@@ -47,7 +47,11 @@ final case class Ogdl(values: Vector[(String, Ogdl)]) extends Dynamic {
         }
     })
 
-  def map(fn: Ogdl => Ogdl) = Ogdl(values.map { case (k, v) => (k, fn(v)) })
+  def map(fn: Ogdl => Ogdl) =
+    Ogdl(values.map {
+      case ("", v) => ("", v)
+      case (k, v)  => (k, fn(v))
+    })
 }
 
 object Ogdl {

--- a/src/ogdl/fury/ogdl/Ogdl.scala
+++ b/src/ogdl/fury/ogdl/Ogdl.scala
@@ -28,9 +28,26 @@ import fury.ogdl.OgdlParser.parse
 import scala.collection.JavaConverters._
 import scala.language.experimental.macros
 import scala.language.higherKinds
+import scala.language.dynamics
 
-final case class Ogdl(values: Vector[(String, Ogdl)]) {
-  def only: String = values.head._1
+final case class Ogdl(values: Vector[(String, Ogdl)]) extends Dynamic {
+  def apply(): String                     = values.head._1
+  def applyDynamic(key: String)(): String = selectDynamic(key).apply()
+  def selectDynamic(key: String): Ogdl    = values.find(_._1 == key).get._2
+
+  // FIXME: Change the type of `set` to `"set"` when upgrading to Scala 2.13.x
+  def applyDynamicNamed(set: String)(updates: (String, Ogdl)*): Ogdl =
+    Ogdl(updates.foldLeft(values) {
+      case (vs, (key, value)) =>
+        vs.indexWhere(_._1 == key) match {
+          case -1 =>
+            vs :+ (key, value)
+          case idx =>
+            vs.patch(idx, Vector((key, value)), 1)
+        }
+    })
+
+  def map(fn: Ogdl => Ogdl) = Ogdl(values.map { case (k, v) => (k, fn(v)) })
 }
 
 object Ogdl {
@@ -73,21 +90,21 @@ object Ogdl {
       path.writeSync(sb.toString).unit
     }
 
-  def read[T: OgdlReader](string: String): T = {
+  def read[T: OgdlReader](string: String, preprocessor: Ogdl => Ogdl): T = {
     val buffer = ByteBuffer.wrap(string.getBytes("UTF-8"))
     val ogdl   = parse(buffer)
 
     implicitly[OgdlReader[T]].read(ogdl)
   }
 
-  def read[T: OgdlReader](path: Path): Outcome[T] =
+  def read[T: OgdlReader](path: Path, preprocessor: Ogdl => Ogdl): Outcome[T] =
     Outcome.rescue[IOException] { _: IOException =>
       FileNotFound(path)
     } {
       val buffer = readToBuffer(path)
       val ogdl   = parse(buffer)
 
-      implicitly[OgdlReader[T]].read(ogdl)
+      implicitly[OgdlReader[T]].read(preprocessor(ogdl))
     }
 
   private[this] def readToBuffer(path: Path): ByteBuffer = {

--- a/src/ogdl/fury/ogdl/OgdlReader.scala
+++ b/src/ogdl/fury/ogdl/OgdlReader.scala
@@ -39,7 +39,9 @@ object OgdlReader {
       else
         caseClass.construct { param =>
           if (map.contains(param.label)) param.typeclass.read(map(param.label))
-          else param.default.getOrElse(throw new RuntimeException(s"missing value ${param.label}"))
+          else
+            param.default.getOrElse(
+                throw new RuntimeException(s"missing value ${param.label} in ${list}"))
         }
   }
 
@@ -54,9 +56,9 @@ object OgdlReader {
         .read(map)
   }
 
-  implicit val string: OgdlReader[String]   = _.only
-  implicit val int: OgdlReader[Int]         = _.only.toInt
-  implicit val boolean: OgdlReader[Boolean] = _.only.toBoolean
+  implicit val string: OgdlReader[String]   = _()
+  implicit val int: OgdlReader[Int]         = _().toInt
+  implicit val boolean: OgdlReader[Boolean] = _().toBoolean
 
   implicit def traversable[Coll[t] <: Traversable[t], T: OgdlReader](
       implicit cbf: CanBuildFrom[Nothing, T, Coll[T]]

--- a/src/project/project.scala
+++ b/src/project/project.scala
@@ -28,7 +28,7 @@ object ProjectCli {
     for {
       layout       <- cli.layout
       config       <- fury.Config.read()(cli.env, layout)
-      layer        <- Layer.read(layout.furyConfig)(layout)
+      layer        <- Layer.read(layout.furyConfig)(layout, cli.shell)
       cli          <- cli.hint(SchemaArg, layer.schemas)
       optSchemaArg <- ~cli.peek(SchemaArg)
     } yield new MenuContext(cli, layout, config, layer, optSchemaArg)

--- a/src/repo/repo.scala
+++ b/src/repo/repo.scala
@@ -29,7 +29,7 @@ object RepoCli {
     for {
       layout <- cli.layout
       config <- fury.Config.read()(cli.env, layout)
-      layer  <- Layer.read(layout.furyConfig)(layout)
+      layer  <- Layer.read(layout.furyConfig)(layout, cli.shell)
     } yield Context(cli, layout, config, layer)
 
   case class Context(cli: Cli[CliParam[_]], layout: Layout, config: Config, layer: Layer)
@@ -70,12 +70,8 @@ object RepoCli {
       dir       <- io(DirArg)
       retry     <- ~io(RetryArg).isSuccess
       bareRepo  <- repo.repo.fetch(layout, cli.shell)
-      _ <- ~cli.shell.git.sparseCheckout(
-              bareRepo,
-              dir,
-              List(),
-              refSpec = repo.refSpec.id,
-              commit = repo.currentCheckout.id)
+      _ <- ~cli.shell.git
+            .sparseCheckout(bareRepo, dir, List(), refSpec = repo.track.id, commit = repo.commit.id)
       newRepo <- ~repo.copy(local = Some(dir))
       lens    <- ~Lenses.layer.repos(schema.id)
       layer   <- ~(lens.modify(layer)(_ - repo + newRepo))
@@ -98,17 +94,16 @@ object RepoCli {
                    .orElse(all.map(_ => schema.repos.map(_.id)))
                    .ascribe(exoskeleton.MissingArg("repo"))
       repos <- optRepos.map(schema.repo(_)(layout, cli.shell)).sequence
-      msgs  <- repos.map(_.repo.update()(cli.shell, layout)).sequence
-      _     <- ~msgs.foreach(io.println(_))
+      msgs  <- repos.map(_.repo.update()(cli.shell, layout).map(io.println(_))).sequence
       lens  <- ~Lenses.layer.repos(schema.id)
       newRepos <- repos
                    .map(
                        repo =>
                          for {
                            commit <- repo.repo
-                                      .getCommitFromTag(layout, cli.shell, repo.refSpec)
+                                      .getCommitFromTag(layout, cli.shell, repo.track)
                                       .map(CheckoutId(_))
-                           newRepo = repo.copy(currentCheckout = commit)
+                           newRepo = repo.copy(commit = commit)
                          } yield (newRepo, repo)
                    )
                    .sequence
@@ -118,8 +113,7 @@ object RepoCli {
       _ <- ~io.save(newLayer, layout.furyConfig)
       _ <- ~newRepos.foreach {
             case (newRepo, _) =>
-              io.println(
-                  s"Repo [${newRepo.id.key}] checked out to commit [${newRepo.currentCheckout.id}]")
+              io.println(s"Repo [${newRepo.id.key}] checked out to commit [${newRepo.commit.id}]")
           }
     } yield io.await()
   }

--- a/src/repo/repo.scala
+++ b/src/repo/repo.scala
@@ -102,7 +102,7 @@ object RepoCli {
                          for {
                            commit <- repo.repo
                                       .getCommitFromTag(layout, cli.shell, repo.track)
-                                      .map(CheckoutId(_))
+                                      .map(Commit(_))
                            newRepo = repo.copy(commit = commit)
                          } yield (newRepo, repo)
                    )
@@ -153,9 +153,9 @@ object RepoCli {
               .map(_.getCommitFromTag(layout, cli.shell, version))
               .getOrElse(Failure(exoskeleton.MissingArg("name")))
       sourceRepo <- repo
-                     .map(SourceRepo(nameArg, _, version, CheckoutId(tag), dir))
+                     .map(SourceRepo(nameArg, _, version, Commit(tag), dir))
                      .orElse(dir.map { d =>
-                       SourceRepo(nameArg, fury.Repo(""), RefSpec.master, CheckoutId(tag), Some(d))
+                       SourceRepo(nameArg, fury.Repo(""), RefSpec.master, Commit(tag), Some(d))
                      })
                      .ascribe(exoskeleton.MissingArg("repo"))
 

--- a/src/schema/schema.scala
+++ b/src/schema/schema.scala
@@ -30,7 +30,7 @@ object SchemaCli {
     for {
       layout <- cli.layout
       config <- fury.Config.read()(cli.env, layout)
-      layer  <- Layer.read(layout.furyConfig)(layout)
+      layer  <- Layer.read(layout.furyConfig)(layout, cli.shell)
     } yield SchemaCtx(cli, layout, config, layer)
 
   def select(ctx: SchemaCtx) = {

--- a/src/source/source.scala
+++ b/src/source/source.scala
@@ -41,7 +41,7 @@ object SourceCli {
     for {
       layout    <- cli.layout
       config    <- Config.read()(cli.env, layout)
-      layer     <- Layer.read(layout.furyConfig)(layout)
+      layer     <- Layer.read(layout.furyConfig)(layout, cli.shell)
       cli       <- cli.hint(SchemaArg, layer.schemas)
       schemaArg <- ~cli.peek(SchemaArg)
       schema    <- ~layer.schemas.findBy(schemaArg.getOrElse(layer.main)).toOption


### PR DESCRIPTION
This will dynamically modify the configuration files before they're interpreted as case classes.

Still to do:

- [x] Do not output migration messages during tab-completion
- [x] Display shorter hashes in repos table
- [x] Mapping over empty lists includes an empty entry