### PR TITLE
support --help alias for help

### DIFF
--- a/etc/fury
+++ b/etc/fury
@@ -75,6 +75,9 @@ case "$1" in
   "completion")
     fury "$@" 2> /dev/null || printf "1:Command:((start:'start the Fury daemon'))\n"
     ;;
+  "--help")
+    fury "help"
+    ;;
   *)
     fury "$@"
     ;;


### PR DESCRIPTION
closes #125 

`--help` support was implemented in the shell script to prevent the pollution of `FuryMenu`