### PR TITLE
Refactor to support better artifact hashing

### DIFF
--- a/etc/install.sh
+++ b/etc/install.sh
@@ -39,10 +39,12 @@ fail() {
   exit 1
 }
 
-stopFury() {
+restartFury() {
   message "Checking for currently-active Fury daemon..."
   type -p fury > /dev/null && \
-  fury stop
+  fury stop && \
+  message "Starting new version of Fury..." && \
+  ${DESTINATION}/bin/fury start
 }
 
 # Remove an existing installation, if there is one.
@@ -146,7 +148,7 @@ completion() {
   echo ""
 }
 
-prepare && checkJava && untarPayload && launchBloop && updateShells && stopFury && completion
+prepare && checkJava && untarPayload && launchBloop && updateShells && restartFury && completion
 
 exit 0
 

--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -200,7 +200,7 @@ object BuildCli {
       _           <- Bloop.server(layout.shell, io)
       compilation <- universe.compilation(io, module.ref(project), layout)
       _           <- ~compilation.checkoutAll(io, layout)
-      _           <- compilation.generateFiles(io, universe, layout)
+      _           <- compilation.generateFiles(io, layout)
       debugStr    <- ~invoc(DebugArg).toOption
       multiplexer <- ~(new Multiplexer[ModuleRef, CompileEvent](
                         module.ref(project) :: artifacts.map(_.ref).to[List]))

--- a/src/core/bloop.scala
+++ b/src/core/bloop.scala
@@ -39,7 +39,7 @@ object Bloop {
     } catch {
       case e: ConnectException =>
         bloopServer.foreach(_.destroy())
-        val io2     = io.print("Starting bloop compile server")
+        val io2     = io.print("Starting bloop compile server...")
         val running = shell.bloop.startServer()
 
         def checkStarted(): Unit =

--- a/src/core/graph.scala
+++ b/src/core/graph.scala
@@ -103,40 +103,16 @@ object Graph {
     nodes.foreach {
       case (node, i) =>
         array(i)(2 * i + 1) = '»'
-        graph(node).foreach { dep =>
+        graph(node).filter(!_.hidden).foreach { dep =>
           overwrite(2 * indexes(dep) + 1, i, East | North)
           for (j <- (2 * indexes(dep) + 1) to (2 * i - 1)) overwrite(j + 1, i, East | West)
           for (j <- (indexes(dep) + 1) to (i - 1)) overwrite(2 * indexes(dep) + 1, j, North | South)
         }
     }
 
-    // compact the tree
-    // FIXME: This is not tail-recursive, and doesn't seem to do compaction in some cases
-    def compact(): Unit = array.zipWithIndex.foreach {
-      case (line, idx) =>
-        val max = line
-          .dropRight(1)
-          .tails
-          .find { t =>
-            t.forall { ch =>
-              (chars.indexOf(ch) & North) == 0
-            }
-          }
-          .get
-          .length
-
-        if (max > 1) {
-          val i = line.length - max - 1
-          for (ln <- idx until array.length) array(ln)(i) = '.'
-          compact()
-        }
-    }
-
-    //compact()
-
     val namedLines = array.zip(nodes).map {
       case (chs, (moduleRef, _)) =>
-        val ModuleRef(ProjectId(p), ModuleId(m), _) = moduleRef
+        val ModuleRef(ProjectId(p), ModuleId(m), _, hidden) = moduleRef
         val text =
           if (describe || state.get(moduleRef) == Some(Compiling))
             theme.project(p) + theme.gray("/") + theme.module(m)

--- a/src/core/layout.scala
+++ b/src/core/layout.scala
@@ -37,19 +37,19 @@ case class Layout(home: Path, pwd: Path, env: Environment) {
   lazy val userConfig: Path   = userDir / "config.fury"
   lazy val aliasesPath: Path  = userDir / "aliases"
 
-  def bloopConfig(artifact: Artifact): Path =
-    bloopDir.extant() / s"${artifact.hash.encoded[Base64Url]}.json"
+  def bloopConfig(digest: Digest): Path =
+    bloopDir.extant() / s"${digest.encoded[Base64Url]}.json"
 
   lazy val furyConfig: Path = pwd / "layer.fury"
 
-  def outputDir(artifact: Artifact): Path =
-    (analysisDir / artifact.hash.encoded[Base64Url]).extant()
+  def outputDir(digest: Digest): Path =
+    (analysisDir / digest.encoded[Base64Url]).extant()
 
-  def classesDir(artifact: Artifact): Path =
-    (classesDir / artifact.hash.encoded[Base64Url]).extant()
+  def classesDir(digest: Digest): Path =
+    (classesDir / digest.encoded[Base64Url]).extant()
 
-  def manifestFile(artifact: Artifact): Path =
-    (resourcesDir / artifact.hash.encoded[Base64Url]).extant() / "manifest.mf"
+  def manifestFile(digest: Digest): Path =
+    (resourcesDir / digest.encoded[Base64Url]).extant() / "manifest.mf"
 
   val shell = Shell(env)
 }

--- a/src/core/shell.scala
+++ b/src/core/shell.scala
@@ -195,8 +195,9 @@ case class Shell(environment: Environment) {
 
     def fetch(io: Io, artifact: String): Outcome[List[Path]] = {
       val items = new ListBuffer[String]()
-      val running = sh"$coursier fetch --progress --repository central $artifact"
-        .async(items.append(_), io.println(_))
+      val running = sh"$coursier fetch --progress --repository central $artifact".async(
+          items.append(_),
+          line => if (!escritoire.Ansi.strip(line).trim.isEmpty) io.println(line))
       val result = running.await()
       if (result == 0) Success(items.to[List].map(Path(_)))
       else Failure(ItemNotFound(msg"$artifact", msg"binary"))

--- a/src/core/tables.scala
+++ b/src/core/tables.scala
@@ -58,7 +58,7 @@ case class Tables(config: Config) {
 
   private def refinedModuleDep(projectId: ProjectId): AnsiShow[SortedSet[ModuleRef]] =
     _.map {
-      case ref @ ModuleRef(p, m, intransitive) =>
+      case ref @ ModuleRef(p, m, intransitive, _) =>
         val extra = (if (intransitive) msg"*" else msg"")
         if (p == projectId) msg"${theme.module(m.key)}$extra"
         else msg"${theme.project(p.key)}${theme.gray("/")}${theme.module(m.key)}$extra"


### PR DESCRIPTION
This avoids different artifacts getting the same hash, and also
increases the usefulness of the `Compilation` type.