### PR TITLE
quickfix: prevent hanging when bloop not in PATH

### DIFF
--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -260,13 +260,20 @@ case class Compilation(
           val out = new StringBuilder()
           multiplexer(artifact.ref) = StartCompile(artifact.ref)
 
-          val compileResult: Boolean = artifact.sourcePaths.isEmpty || blocking {
-            layout.shell.bloop
-              .compile(hash(moduleRef).encoded) { ln =>
-                out.append(ln)
-                out.append("\n")
-              }
-              .await() == 0
+          val compileResult: Boolean = Try {
+            artifact.sourcePaths.isEmpty || blocking {
+              layout.shell.bloop
+                .compile(artifact.hash.encoded) { ln =>
+                  out.append(ln)
+                  out.append("\n")
+                }
+                .await() == 0
+            }
+          }.recover {
+            case e =>
+              io.println(e.getClass.toString ++ ": " ++ e.getMessage)
+              io.println(e.getStackTrace.mkString("\n"))
+              false
           }
 
           val finalResult = if (compileResult && artifact.kind == Application) {

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -263,7 +263,7 @@ case class Compilation(
           val compileResult: Boolean = Try {
             artifact.sourcePaths.isEmpty || blocking {
               layout.shell.bloop
-                .compile(artifact.hash.encoded) { ln =>
+                .compile(hash(artifact).encoded) { ln =>
                   out.append(ln)
                   out.append("\n")
                 }

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -270,11 +270,11 @@ case class Compilation(
                 .await() == 0
             }
           }.recover {
-            case e =>
+            case e: Exception =>
               io.println(e.getClass.toString ++ ": " ++ e.getMessage)
               io.println(e.getStackTrace.mkString("\n"))
               false
-          }
+          }.getOrElse(false)
 
           val finalResult = if (compileResult && artifact.kind == Application) {
             layout.shell

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -263,7 +263,7 @@ case class Compilation(
           val compileResult: Boolean = Try {
             artifact.sourcePaths.isEmpty || blocking {
               layout.shell.bloop
-                .compile(hash(artifact).encoded) { ln =>
+                .compile(hash(artifact.ref).encoded) { ln =>
                   out.append(ln)
                   out.append("\n")
                 }


### PR DESCRIPTION
It seems that guillotine sometimes throws exceptions. If this happened
in `compile` function, the `StopCompile` message was never sent to the
multiplexed so there was an infinite loop in multiplexer thread.

The proper solution will be to fix guillotine and ensure the
multiplexer task always exits.

closes #229