### PR TITLE
Wait for bloop server after starting it.

### DIFF
--- a/src/core/bloop.scala
+++ b/src/core/bloop.scala
@@ -24,6 +24,7 @@ import guillotine._
 import mercator._
 
 import scala.util._
+import scala.concurrent.duration._
 
 object Bloop {
 
@@ -42,28 +43,39 @@ object Bloop {
         val io2     = io.print("Starting bloop compile server")
         val running = shell.bloop.startServer()
 
-        def checkStarted(): Unit =
-          try {
-            Thread.sleep(150)
-            if (!testServer().isSuccess) {
-              io.print(".")
-              checkStarted()
+        def checkStarted(n: Duration): Boolean = {
+          val interval = 150.millis
+          if (n < interval) {
+            false
+          } else {
+            try {
+              if (!testServer().isSuccess) {
+                io.print(".")
+                Thread.sleep((interval / 1.millisecond).toInt)
+                checkStarted(n - interval)
+              } else {
+                true
+              }
+            } catch {
+              case e: Exception =>
+                io.print(".")
+                Thread.sleep((interval / 1.millisecond).toInt)
+                checkStarted(n - interval)
             }
-          } catch {
-            case e: Exception =>
-              io.print(".")
-              checkStarted()
           }
-
-        io.println("done")
-
-        try {
-          bloopServer = Some(running)
-          Success(())
-        } catch {
-          case e: ConnectException =>
-            bloopServer = None
-            Failure(InitFailure())
+        }
+        if (checkStarted(5 seconds)) {
+          io.println("done")
+          try {
+            bloopServer = Some(running)
+            Success(())
+          } catch {
+            case e: ConnectException =>
+              bloopServer = None
+              Failure(InitFailure())
+          }
+        } else {
+          Failure(InitFailure())
         }
     }
   }

--- a/test/policy_file_test/run.sh
+++ b/test/policy_file_test/run.sh
@@ -4,8 +4,6 @@ set -x
 
 source $TESTROOTDIR/tests_lib
 
-start_bloop
-fury start
 fury layer init
 fury project add -n policy_file_test
 fury repo add -u https://github.com/propensive/base.git -n base

--- a/test/repos_pull/run.sh
+++ b/test/repos_pull/run.sh
@@ -4,8 +4,6 @@ set -x
 
 source $TESTROOTDIR/tests_lib
 
-start_bloop
-
 mkdir -p repo1
 (
     cd repo1
@@ -44,8 +42,6 @@ mkdir -p fury_project
     cd repo1
     touch src/version3 && git add -A && git commit -m"."
 )
-
-start_bloop
 
 git clone fury_project fury_project_clone 2> /dev/null
 

--- a/test/run_all
+++ b/test/run_all
@@ -45,7 +45,7 @@ run_test_case(){
     local test_dir=$(mktemp -d /tmp/fury_verification_${name}-XXXXXXXX)
     local logs="${test_dir}/logs.txt"
     local errors="${test_dir}/errors.txt"
-
+    fury restart
     (cp -r "${test_case}/." "${test_dir}" && \
         cd ${test_dir} && \
         bash -c "${test_case}/run.sh"

--- a/test/simple_project/run.sh
+++ b/test/simple_project/run.sh
@@ -4,8 +4,6 @@ set -x
 
 source $TESTROOTDIR/tests_lib
 
-start_bloop
-fury start
 fury layer init
 fury project add -n webpage
 fury module add -n hello_world

--- a/test/undo_command/run.sh
+++ b/test/undo_command/run.sh
@@ -4,8 +4,6 @@ set -x
 
 source $TESTROOTDIR/tests_lib
 
-start_bloop
-fury start
 fury layer init
 fury project add -n webpage
 fury module add -n hello_world


### PR DESCRIPTION
As a result, we don't need to manually start bloop server in tests

closes #236