### PR TITLE
Portable sed command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ dist/bundle/bin/launcher: dist/bundle/bin/coursier
 
 dist/bundle/bin/ng: dist/bundle/bin
 	curl -s -L -o $@ https://raw.githubusercontent.com/facebook/nailgun/master/nailgun-client/py/ng.py
-	sed -i '1 s/$$/2/' $@
+	sed -i.bak '1 s/$$/2/' $@ && rm $@.bak
 	chmod +x $@
 
 native_image_jar_files=$(jar_files) $(NAILGUNJAR_PATH) $(scala_libs)


### PR DESCRIPTION
The sed command used in dist/bundle/bin/ng does not work on macOS (BSD) sed. Replaced with a portable version that should work both on Mac and Linux. 
