### PR TITLE
Add a `make install` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,8 +149,10 @@ clean: clean-dist
 	rm -rf bootstrap/bin/fury
 	rm -rf bootstrap
 
-.PHONY: all publish compile watch bloop-clean clean-compile clean-dist clean test ci clean-ci test-isolated integration-isolated integration $(TESTS) all-jars
-
-.PHONY: download
 download: $(REPOS) dist/bundle/bin/coursier dist/bundle/bin/ng dist/bundle/bin/launcher dist/bundle/lib/$(NAILGUNJAR) bootstrap/scala
 	dist/bundle/bin/launcher --skip-bsp-connection $(BLOOPVERSION) # to download bloop
+
+install: dist/install.sh
+	yes | dist/install.sh
+
+.PHONY: all publish compile watch bloop-clean clean-compile clean-dist clean test ci clean-ci test-isolated integration-isolated integration $(TESTS) all-jars download install

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,6 @@ download: $(REPOS) dist/bundle/bin/coursier dist/bundle/bin/ng dist/bundle/bin/l
 	dist/bundle/bin/launcher --skip-bsp-connection $(BLOOPVERSION) # to download bloop
 
 install: dist/install.sh
-	yes | dist/install.sh
+	dist/install.sh
 
 .PHONY: all publish compile watch bloop-clean clean-compile clean-dist clean test ci clean-ci test-isolated integration-isolated integration $(TESTS) all-jars download install


### PR DESCRIPTION
You can now install the latest version of `Fury` in a single step - not very exciting!