### PR TITLE
Remove single quotes from build/native menu description

### DIFF
--- a/src/menu/menu.scala
+++ b/src/menu/menu.scala
@@ -37,10 +37,7 @@ object FuryMenu {
             Action('compile, msg"compile a module", BuildCli.compile(None, None)),
             Action('describe, msg"describe the build for a module", BuildCli.describe),
             Action('save, msg"save a JAR file", BuildCli.save),
-            Action(
-                'native,
-                msg"build a native executable using GraalVM's 'native-image'",
-                BuildCli.native)
+            Action('native, msg"build a native executable using GraalVM", BuildCli.native)
         ),
         Menu('clean, msg"clean fury workspace", CleanCli.context, 'all)(
             Action('all, msg"clean all", CleanCli.cleanAll),


### PR DESCRIPTION
They were not being escaped, so they were causing completion to break. A
better solution would be to fix the escaping, but we're probably going
to rewrite it soon.