### PR TITLE
Added access to more parameters to security profile

### DIFF
--- a/etc/security/fury_application_module.policy
+++ b/etc/security/fury_application_module.policy
@@ -2,4 +2,7 @@ grant {
       permission java.io.FilePermission "${fury.sharedDir}${/}-", "read,write";
       permission java.lang.RuntimePermission "getenv.SHARED", "read";
       permission java.util.PropertyPermission "fury.sharedDir", "read";
+      permission java.util.PropertyPermission "scala.maven.version.number", "read";
+      permission java.util.PropertyPermission "scala.version.number", "read";
+      permission java.util.PropertyPermission "scala.copyright.string", "read";
 };


### PR DESCRIPTION
When trying to build shapeless with Scala 2.11, certain parameters were
not accessible due to the security profile.

There may be more, but these failures have now been circumvented.