### PR TITLE
 Fill `dependencies` field in bloop config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,13 @@ dist/
 git/
 bootstrap/
 .bloop/
+.fury
+.idea
+*~
+**/#*
+**/.#*
+log
+project
+target
+lib
+test-lib

--- a/src/core-test/fury/Tests.scala
+++ b/src/core-test/fury/Tests.scala
@@ -4,6 +4,7 @@ import probably.TestApp
 
 object Tests {
   private val testSuites = List[TestApp](
+      DirectedGraphTest,
       LayerRepositoryTest
   )
 

--- a/src/core-test/fury/directedgraph/DirectedGraphTest.scala
+++ b/src/core-test/fury/directedgraph/DirectedGraphTest.scala
@@ -1,0 +1,83 @@
+/*
+  Fury, version 0.4.0. Copyright 2018-19 Jon Pretty, Propensive Ltd.
+
+  The primary distribution site is: https://propensive.com/
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+  in compliance with the License. You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required  by applicable  law or  agreed to  in writing,  software  distributed  under the
+  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  express  or  implied.  See  the  License for  the specific  language  governing  permissions and
+  limitations under the License.
+ */
+package fury
+
+import java.nio.ByteBuffer
+import java.nio.ByteBuffer.wrap
+
+import probably._
+
+import scala.language.implicitConversions
+
+object DirectedGraphTest extends TestApp {
+
+  override def tests(): Unit = {
+    test("Graph with no edges has no cycles") {
+      DirectedGraph[Int](Map(1 -> Set()))
+    }.assert(!_.hasCycle(1))
+
+    test("Single vertex pointing to itself is a cycle") {
+      DirectedGraph[Int](Map(1 -> Set(1)))
+    }.assert(_.hasCycle(1))
+
+    test("Two vertices pointing to each other build a cycle") {
+      DirectedGraph[Int](Map(1 -> Set(2), 2 -> Set(1)))
+    }.assert(_.hasCycle(1))
+
+    test("Two vertices with one connection") {
+      DirectedGraph[Int](Map(1 -> Set(2)))
+    }.assert(!_.hasCycle(1))
+
+    test("Find a cycle not containing startpoint") {
+      DirectedGraph(Map(1 -> Set(2), 2 -> Set(3), 3 -> Set(4), 4 -> Set(2)))
+    }.assert(_.findCycle(1) == Some(List(1, 2, 3, 4, 2)))
+
+    test("Diamond without cycles") {
+      DirectedGraph(Map(1 -> Set(2, 3), 2 -> Set(4), 3 -> Set(4)))
+    }.assert(!_.hasCycle(1))
+
+    test("single element") {
+      DirectedGraph(Map(1 -> Set.empty[Int])).subgraph(Set(1))
+    }.assert(_ == DirectedGraph(Map(1 -> Set.empty[Int])))
+
+    test("two separate elements") {
+      val input = DirGraph(Map(1 -> Set(2), 2 -> Set.empty[Int]))
+      input.subgraph(Set(1, 2))
+    }.assert { _ == DirGraph(Map(1 -> Set(2), 2 -> Set.empty[Int])) }
+
+    test("two related elements") {
+      val input = DirectedGraph(Map(1 -> Set(2), 2 -> Set.empty[Int]))
+      input.subgraph(Set(1))
+    }.assert { _ == DirectedGraph(Map(1 -> Set.empty[Int])) }
+
+    test("remove two elements") {
+      val input = DirectedGraph(Map(1 -> Set(2), 2 -> Set(3), 3 -> Set.empty[Int]))
+      input.subgraph(Set(1))
+    }.assert { _ == DirectedGraph(Map(1 -> Set.empty[Int])) }
+
+    test("remove one element of three") {
+      val input = DirectedGraph(Map(1 -> Set(2), 2 -> Set(3), 3 -> Set.empty[Int]))
+      input.subgraph(Set(1, 2))
+    }.assert { _ == DirectedGraph(Map(1 -> Set(2), 2 -> Set.empty[Int])) }
+
+    test("remove two element of four") {
+      val input =
+        DirectedGraph(Map(1 -> Set(2, 4), 2 -> Set(3, 4), 3 -> Set(4), 4 -> Set.empty[Int]))
+      input.subgraph(Set(1, 2))
+    }.assert { _ == DirectedGraph(Map(1 -> Set(2), 2 -> Set.empty[Int])) }
+
+  }
+}

--- a/src/core-test/fury/directedgraph/DirectedGraphTest.scala
+++ b/src/core-test/fury/directedgraph/DirectedGraphTest.scala
@@ -54,9 +54,9 @@ object DirectedGraphTest extends TestApp {
     }.assert(_ == DirectedGraph(Map(1 -> Set.empty[Int])))
 
     test("two separate elements") {
-      val input = DirGraph(Map(1 -> Set(2), 2 -> Set.empty[Int]))
+      val input = DirectedGraph(Map(1 -> Set(2), 2 -> Set.empty[Int]))
       input.subgraph(Set(1, 2))
-    }.assert { _ == DirGraph(Map(1 -> Set(2), 2 -> Set.empty[Int])) }
+    }.assert { _ == DirectedGraph(Map(1 -> Set(2), 2 -> Set.empty[Int])) }
 
     test("two related elements") {
       val input = DirectedGraph(Map(1 -> Set(2), 2 -> Set.empty[Int]))

--- a/src/core/bloop.scala
+++ b/src/core/bloop.scala
@@ -98,7 +98,7 @@ object Bloop {
       classpath <- ~compilation.classpath(artifact.ref, layout)
       compilerClasspath <- ~artifact.compiler.map { c =>
                             compilation.classpath(c.ref, layout)
-                          }.getOrElse(Set())
+                          }.getOrElse(classpath)
       bloopSpec = artifact.compiler
         .flatMap(_.bloopSpec)
         .getOrElse(BloopSpec("org.scala-lang", "scala-compiler", "2.12.7"))

--- a/src/core/bloop.scala
+++ b/src/core/bloop.scala
@@ -96,9 +96,9 @@ object Bloop {
     for {
       _         <- ~compilation.writePlugin(artifact.ref, layout)
       classpath <- ~compilation.classpath(artifact.ref, layout)
-      compilerClasspath <- ~(artifact.compiler.map { c =>
+      compilerClasspath <- ~artifact.compiler.map { c =>
                             compilation.classpath(c.ref, layout)
-                          }.getOrElse(Set()))
+                          }.getOrElse(Set())
       bloopSpec = artifact.compiler
         .flatMap(_.bloopSpec)
         .getOrElse(BloopSpec("org.scala-lang", "scala-compiler", "2.12.7"))
@@ -110,7 +110,9 @@ object Bloop {
               name = compilation.hash(artifact.ref).encoded[Base64Url],
               directory = layout.pwd.value,
               sources = artifact.sourcePaths.map(_.value),
-              dependencies = Nil,
+              dependencies = compilation
+                .allDependenciesGraph(artifact.ref)
+                .map(compilation.hash(_).encoded[Base64Url]),
               classpath = (classpath ++ compilerClasspath).map(_.value),
               out = str"${layout.outputDir(compilation.hash(artifact.ref)).value}",
               classesDir = str"${layout.classesDir(compilation.hash(artifact.ref)).value}",

--- a/src/core/directedgraph.scala
+++ b/src/core/directedgraph.scala
@@ -1,0 +1,60 @@
+package fury
+import scala.annotation.tailrec
+
+case class DirectedGraph[T](connections: Map[T, Set[T]]) {
+
+  def remove(element: T): DirectedGraph[T] = {
+    val pointingTo = connections(element)
+    val noFromEdge = connections - element
+    DirectedGraph(noFromEdge.mapValues { x =>
+      if (x(element)) x ++ pointingTo - element else x
+    })
+  }
+
+  def subgraph(verticesToLeave: Set[T]): DirectedGraph[T] = {
+    val toCut = connections.keySet &~ verticesToLeave
+    toCut.foldRight(this) { (element, graph) =>
+      graph.remove(element)
+    }
+  }
+
+  def neighbours(start: T): Set[T] =
+    connections.getOrElse(start, Set())
+
+  def findCycle(start: T): Option[List[T]] = {
+    @tailrec
+    def findCycleHelper(queue: List[(T, List[T])], finished: Set[T]): Option[List[T]] =
+      queue match {
+        case List() => None
+        case (vertex, trace) :: tail => {
+          val commonElement = trace.toSet.intersect(neighbours(vertex)).headOption
+          commonElement match {
+            case Some(element) => Some(trace ++ List(vertex, element))
+            case None =>
+              findCycleHelper(
+                  tail ++ neighbours(vertex).diff(finished).toList.map((_, trace :+ vertex)),
+                  finished + vertex)
+          }
+        }
+      }
+
+    findCycleHelper(List((start, List())), Set())
+  }
+
+  def hasCycle(start: T): Boolean = findCycle(start).isDefined
+
+  def allDescendants(start: T): Either[List[T], Set[T]] = {
+    @tailrec
+    def allDescendantsHelper(stack: List[T], ans: Set[T]): Set[T] =
+      stack match {
+        case List()       => ans
+        case head :: tail => allDescendantsHelper(neighbours(head).toList ++ tail, ans + head)
+      }
+
+    findCycle(start) match {
+      case Some(cycle) => Left(cycle)
+      case None        => Right(neighbours(start).flatMap(c => allDescendantsHelper(List(c), Set())))
+    }
+  }
+
+}

--- a/src/core/stream.scala
+++ b/src/core/stream.scala
@@ -56,4 +56,8 @@ final class Multiplexer[K, V](keys: List[K]) {
   /** This method should only ever be called from one thread for any given reference, to
     *  guarantee safe concurrent access. */
   def close(key: K): Unit = closed(refs(key)) = true
+
+  def closeAll(): Unit = keys.foreach { k =>
+    closed(refs(k)) = true
+  }
 }


### PR DESCRIPTION
1. Bloop is not executed for each target, but only for
active module and application modules it depends on. The
application models are executed in the order related to their
dependency structure.
2. Safe finalization of multiplexer.