### PR TITLE
Default compiler per project

### DIFF
--- a/layer.fury
+++ b/layer.fury
@@ -19,6 +19,7 @@ schemas	default	id	default
 				main	Some	core
 				license	apache-2.0
 				description	
+				compiler	None
 			escritoire	id	escritoire
 				modules	core	id	core
 						kind	Library
@@ -38,6 +39,7 @@ schemas	default	id	default
 				main	Some	core
 				license	apache-2.0
 				description	
+				compiler	None
 			eucalyptus	id	eucalyptus
 				modules	core	id	core
 						kind	Library
@@ -57,6 +59,7 @@ schemas	default	id	default
 				main	Some	core
 				license	apache-2.0
 				description	
+				compiler	None
 			exoskeleton	id	exoskeleton
 				modules	core	id	core
 						kind	Library
@@ -79,6 +82,7 @@ schemas	default	id	default
 				main	Some	core
 				license	apache-2.0
 				description	
+				compiler	None
 			fury	id	fury
 				modules	build	id	build
 						kind	Library
@@ -363,6 +367,10 @@ schemas	default	id	default
 				main	Some	menu
 				license	apache-2.0
 				description	
+				compiler	Some	projectId	scala
+						moduleId	compiler
+						intransitive	true
+						hidden	false
 			gastronomy	id	gastronomy
 				modules	core	id	core
 						kind	Library
@@ -385,6 +393,7 @@ schemas	default	id	default
 				main	Some	core
 				license	apache-2.0
 				description	
+				compiler	None
 			guillotine	id	guillotine
 				modules	core	id	core
 						kind	Library
@@ -429,6 +438,7 @@ schemas	default	id	default
 				main	Some	macros
 				license	apache-2.0
 				description	
+				compiler	None
 			kaleidoscope	id	kaleidoscope
 				modules	core	id	core
 						kind	Library
@@ -451,6 +461,7 @@ schemas	default	id	default
 				main	Some	core
 				license	apache-2.0
 				description	
+				compiler	None
 			magnolia	id	magnolia
 				modules	core	id	core
 						kind	Library
@@ -473,6 +484,7 @@ schemas	default	id	default
 				main	Some	core
 				license	apache-2.0
 				description	
+				compiler	None
 			mercator	id	mercator
 				modules	core	id	core
 						kind	Library
@@ -492,6 +504,7 @@ schemas	default	id	default
 				main	Some	core
 				license	apache-2.0
 				description	
+				compiler	None
 			mitigation	id	mitigation
 				modules	core	id	core
 						kind	Library
@@ -514,6 +527,7 @@ schemas	default	id	default
 				main	Some	core
 				license	apache-2.0
 				description	
+				compiler	None
 			optometry	id	optometry
 				modules	core	id	core
 						kind	Library
@@ -533,6 +547,7 @@ schemas	default	id	default
 				main	None
 				license	apache-2.0
 				description	
+				compiler	None
 			probation	id	probation
 				modules	cli	id	cli
 						kind	Library
@@ -592,9 +607,13 @@ schemas	default	id	default
 						binaries	
 						resources	
 						bloopSpec	None
-				main	Some	cli
+				main	None
 				license	apache-2.0
 				description	
+				compiler	Some	projectId	scala
+						moduleId	compiler
+						intransitive	true
+						hidden	false
 			totalitarian	id	totalitarian
 				modules	core	id	core
 						kind	Library
@@ -614,6 +633,7 @@ schemas	default	id	default
 				main	Some	core
 				license	apache-2.0
 				description	
+				compiler	None
 		repos	contextual	id	contextual
 				repo	git@github.com:propensive/contextual.git
 				track	fury
@@ -682,7 +702,7 @@ schemas	default	id	default
 			scala	id	scala
 				repo	git@github.com:propensive/.scala.git
 				track	master
-				commit	f0f96b58b78bad6fec5000a9fab3610de7ec7a9f
+				commit	94e03663a05fa2568b31e4315dea1e0d94513cc0
 				local	None
 			totalitarian	id	totalitarian
 				repo	git@github.com:propensive/totalitarian.git

--- a/layer.fury
+++ b/layer.fury
@@ -1,14 +1,15 @@
-version	2
+version	3
 schemas	default	id	default
 		projects	contextual	id	contextual
 				modules	core	id	core
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	
 						params	
 						sources	contextual:src/core	contextual:src/core
@@ -20,13 +21,14 @@ schemas	default	id	default
 				description	
 			escritoire	id	escritoire
 				modules	core	id	core
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	
 						params	
 						sources	escritoire:src/core	escritoire:src/core
@@ -38,13 +40,14 @@ schemas	default	id	default
 				description	
 			eucalyptus	id	eucalyptus
 				modules	core	id	core
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	
 						params	
 						sources	eucalyptus:src/core	eucalyptus:src/core
@@ -56,16 +59,18 @@ schemas	default	id	default
 				description	
 			exoskeleton	id	exoskeleton
 				modules	core	id	core
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	mitigation/core	projectId	mitigation
 								moduleId	core
 								intransitive	false
+								hidden	false
 						params	
 						sources	exoskeleton:src/core	exoskeleton:src/core
 						binaries	
@@ -76,121 +81,144 @@ schemas	default	id	default
 				description	
 			fury	id	fury
 				modules	build	id	build
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	fury/core	projectId	fury
 								moduleId	core
 								intransitive	false
+								hidden	false
 						params	
-						sources	fury:src/build	fury:src/build
+						sources	src/build	src/build
 						binaries	
 						resources	
 						bloopSpec	None
 					core	id	core
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	escritoire/core	projectId	escritoire
 								moduleId	core
 								intransitive	false
+								hidden	false
 							eucalyptus/core	projectId	eucalyptus
 								moduleId	core
 								intransitive	false
+								hidden	false
 							exoskeleton/core	projectId	exoskeleton
 								moduleId	core
 								intransitive	false
+								hidden	false
 							fury/ogdl	projectId	fury
 								moduleId	ogdl
 								intransitive	false
+								hidden	false
 							gastronomy/core	projectId	gastronomy
 								moduleId	core
 								intransitive	false
+								hidden	false
 							guillotine/core	projectId	guillotine
 								moduleId	core
 								intransitive	false
+								hidden	false
 							optometry/core	projectId	optometry
 								moduleId	core
 								intransitive	false
+								hidden	false
 						params	
-						sources	fury:src/core	fury:src/core
+						sources	src/core	src/core
 						binaries	
 						resources	
 						bloopSpec	None
 					dependency	id	dependency
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	fury/core	projectId	fury
 								moduleId	core
 								intransitive	false
+								hidden	false
 						params	
-						sources	fury:src/dependency	fury:src/dependency
+						sources	src/dependency	src/dependency
 						binaries	
 						resources	
 						bloopSpec	None
 					imports	id	imports
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	fury/core	projectId	fury
 								moduleId	core
 								intransitive	false
+								hidden	false
 						params	
-						sources	fury:src/imports	fury:src/imports
+						sources	src/imports	src/imports
 						binaries	
 						resources	
 						bloopSpec	None
 					menu	id	menu
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	fury/build	projectId	fury
 								moduleId	build
 								intransitive	false
+								hidden	false
 							fury/dependency	projectId	fury
 								moduleId	dependency
 								intransitive	false
+								hidden	false
 							fury/imports	projectId	fury
 								moduleId	imports
 								intransitive	false
+								hidden	false
 							fury/module	projectId	fury
 								moduleId	module
 								intransitive	false
+								hidden	false
 							fury/project	projectId	fury
 								moduleId	project
 								intransitive	false
+								hidden	false
 							fury/repo	projectId	fury
 								moduleId	repo
 								intransitive	false
+								hidden	false
 							fury/schema	projectId	fury
 								moduleId	schema
 								intransitive	false
+								hidden	false
 							fury/source	projectId	fury
 								moduleId	source
 								intransitive	false
+								hidden	false
 						params	
-						sources	fury:src/menu	fury:src/menu
+						sources	src/menu	src/menu
 						binaries	com.facebook:nailgun-server:1.0.0	binRepo	central
 								group	com.facebook
 								artifact	nailgun-server
@@ -198,121 +226,137 @@ schemas	default	id	default
 						resources	
 						bloopSpec	None
 					module	id	module
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	fury/core	projectId	fury
 								moduleId	core
 								intransitive	false
+								hidden	false
 						params	
-						sources	fury:src/module	fury:src/module
+						sources	src/module	src/module
 						binaries	
 						resources	
 						bloopSpec	None
 					ogdl	id	ogdl
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	fury/strings	projectId	fury
 								moduleId	strings
 								intransitive	false
+								hidden	false
 							kaleidoscope/core	projectId	kaleidoscope
 								moduleId	core
 								intransitive	false
+								hidden	false
 							magnolia/core	projectId	magnolia
 								moduleId	core
 								intransitive	false
+								hidden	false
 							mitigation/core	projectId	mitigation
 								moduleId	core
 								intransitive	false
+								hidden	false
 						params	
-						sources	fury:src/ogdl	fury:src/ogdl
+						sources	src/ogdl	src/ogdl
 						binaries	
 						resources	
 						bloopSpec	None
 					project	id	project
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	fury/core	projectId	fury
 								moduleId	core
 								intransitive	false
+								hidden	false
 						params	
-						sources	fury:src/project	fury:src/project
+						sources	src/project	src/project
 						binaries	
 						resources	
 						bloopSpec	None
 					repo	id	repo
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	fury/core	projectId	fury
 								moduleId	core
 								intransitive	false
+								hidden	false
 						params	
-						sources	fury:src/repo	fury:src/repo
+						sources	src/repo	src/repo
 						binaries	
 						resources	
 						bloopSpec	None
 					schema	id	schema
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	fury/core	projectId	fury
 								moduleId	core
 								intransitive	false
+								hidden	false
 						params	
-						sources	fury:src/schema	fury:src/schema
+						sources	src/schema	src/schema
 						binaries	
 						resources	
 						bloopSpec	None
 					source	id	source
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	fury/core	projectId	fury
 								moduleId	core
 								intransitive	false
+								hidden	false
 						params	
-						sources	fury:src/source	fury:src/source
+						sources	src/source	src/source
 						binaries	
 						resources	
 						bloopSpec	None
 					strings	id	strings
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	
 						params	
-						sources	fury:src/strings	fury:src/strings
+						sources	src/strings	src/strings
 						binaries	
 						resources	
 						bloopSpec	None
@@ -321,16 +365,18 @@ schemas	default	id	default
 				description	
 			gastronomy	id	gastronomy
 				modules	core	id	core
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	magnolia/core	projectId	magnolia
 								moduleId	core
 								intransitive	false
+								hidden	false
 						params	
 						sources	gastronomy:src/core	gastronomy:src/core
 						binaries	
@@ -341,35 +387,40 @@ schemas	default	id	default
 				description	
 			guillotine	id	guillotine
 				modules	core	id	core
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	guillotine/macros	projectId	guillotine
 								moduleId	macros
 								intransitive	false
+								hidden	false
 						params	
 						sources	guillotine:src/core	guillotine:src/core
 						binaries	
 						resources	
 						bloopSpec	None
 					macros	id	macros
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	contextual/core	projectId	contextual
 								moduleId	core
 								intransitive	false
+								hidden	false
 							mitigation/core	projectId	mitigation
 								moduleId	core
 								intransitive	false
+								hidden	false
 						params	
 						sources	guillotine:src/macros	guillotine:src/macros
 						binaries	
@@ -380,16 +431,18 @@ schemas	default	id	default
 				description	
 			kaleidoscope	id	kaleidoscope
 				modules	core	id	core
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	contextual/core	projectId	contextual
 								moduleId	core
 								intransitive	false
+								hidden	false
 						params	
 						sources	kaleidoscope:src/core	kaleidoscope:src/core
 						binaries	
@@ -400,16 +453,18 @@ schemas	default	id	default
 				description	
 			magnolia	id	magnolia
 				modules	core	id	core
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	mercator/core	projectId	mercator
 								moduleId	core
 								intransitive	false
+								hidden	false
 						params	
 						sources	magnolia:src/core	magnolia:src/core
 						binaries	
@@ -420,13 +475,14 @@ schemas	default	id	default
 				description	
 			mercator	id	mercator
 				modules	core	id	core
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	
 						params	
 						sources	mercator:src/core	mercator:src/core
@@ -438,16 +494,18 @@ schemas	default	id	default
 				description	
 			mitigation	id	mitigation
 				modules	core	id	core
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	totalitarian/core	projectId	totalitarian
 								moduleId	core
 								intransitive	false
+								hidden	false
 						params	
 						sources	mitigation:src/core	mitigation:src/core
 						binaries	
@@ -458,13 +516,14 @@ schemas	default	id	default
 				description	
 			optometry	id	optometry
 				modules	core	id	core
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	
 						params	
 						sources	optometry:src/core	optometry:src/core
@@ -476,51 +535,58 @@ schemas	default	id	default
 				description	
 			probation	id	probation
 				modules	cli	id	cli
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	escritoire/core	projectId	escritoire
 								moduleId	core
 								intransitive	false
+								hidden	false
 							probation/core	projectId	probation
 								moduleId	core
 								intransitive	false
+								hidden	false
 						params	
 						sources	probation:src/cli	probation:src/cli
 						binaries	
 						resources	
 						bloopSpec	None
 					core	id	core
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	probation/macros	projectId	probation
 								moduleId	macros
 								intransitive	false
+								hidden	false
 						params	
 						sources	probation:src/core	probation:src/core
 						binaries	
 						resources	
 						bloopSpec	None
 					macros	id	macros
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	magnolia/core	projectId	magnolia
 								moduleId	core
 								intransitive	false
+								hidden	false
 						params	
 						sources	probation:src/macros	probation:src/macros
 						binaries	
@@ -531,13 +597,14 @@ schemas	default	id	default
 				description	
 			totalitarian	id	totalitarian
 				modules	core	id	core
-						kind	library
+						kind	Library
 						main	None
 						plugin	None
 						manifest	
 						compiler	projectId	scala
 							moduleId	compiler
 							intransitive	true
+							hidden	false
 						after	
 						params	
 						sources	totalitarian:src/core	totalitarian:src/core

--- a/src/core/args.scala
+++ b/src/core/args.scala
@@ -38,13 +38,14 @@ object Args {
   val BinaryRepoArg =
     CliParam[BinRepoId]('r', 'repo, "Specify the repository from which to fetch binaries")
 
-  val AliasArg    = CliParam[AliasCmd]('a', 'alias, "specify a command alias")
-  val BinaryArg   = CliParam[String]('b', 'binary, "specify a binary dependency")
-  val CompilerArg = CliParam[String]('c', 'compiler, "specify a compiler")
-  val LinkArg     = CliParam[String]('l', 'link, "specify a dependency link to another module")
-  val SourceArg   = CliParam[String]('d', 'source, "specify a source directory")
-  val DirArg      = CliParam[Path]('d', 'dir, "specify the new repository destination directory")
-  val DebugArg    = CliParam[String]('D', 'debug, "specify a module to debug")
+  val AliasArg           = CliParam[AliasCmd]('a', 'alias, "specify a command alias")
+  val BinaryArg          = CliParam[String]('b', 'binary, "specify a binary dependency")
+  val CompilerArg        = CliParam[String]('c', 'compiler, "specify a compiler")
+  val DefaultCompilerArg = CliParam[String]('c', 'compiler, "specify a default compiler")
+  val LinkArg            = CliParam[String]('l', 'link, "specify a dependency link to another module")
+  val SourceArg          = CliParam[String]('d', 'source, "specify a source directory")
+  val DirArg             = CliParam[Path]('d', 'dir, "specify the new repository destination directory")
+  val DebugArg           = CliParam[String]('D', 'debug, "specify a module to debug")
 
   val DescriptionArg =
     CliParam[String]('D', 'description, "specify a brief description of the project")

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -170,6 +170,7 @@ case class Compilation(
               },
               artifact.params,
               artifact.intransitive,
+              artifact.sourcePaths,
               graph(ref).map(hash(_))).digest[Md5]
         }
     )

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -602,6 +602,13 @@ object ModuleRef {
 
   val JavaRef = ModuleRef(ProjectId("java"), ModuleId("compiler"), false)
 
+  def parseFull(string: String, intransitive: Boolean): Try[ModuleRef] = string match {
+    case r"$projectId@([a-z][a-z0-9\-]*[a-z0-9])\/$moduleId@([a-z][a-z0-9\-]*[a-z0-9])" =>
+      Success(ModuleRef(ProjectId(projectId), ModuleId(moduleId), intransitive))
+    case _ =>
+      Failure(ItemNotFound(ModuleId(string)))
+  }
+
   def parse(project: Project, string: String, intransitive: Boolean): Try[ModuleRef] =
     string match {
       case r"$projectId@([a-z][a-z0-9\-]*[a-z0-9])\/$moduleId@([a-z][a-z0-9\-]*[a-z0-9])" =>
@@ -906,7 +913,8 @@ case class Project(
     modules: SortedSet[Module] = TreeSet(),
     main: Option[ModuleId] = None,
     license: LicenseId = License.unknown,
-    description: String = "") {
+    description: String = "",
+    compiler: Option[ModuleRef] = None) {
   def moduleRefs: List[ModuleRef] = modules.to[List].map(_.ref(this))
 
   def mainModule: Try[Option[Module]] =

--- a/src/core/lenses.scala
+++ b/src/core/lenses.scala
@@ -122,6 +122,9 @@ object Lenses {
     def mainModule(schemaId: SchemaId, projectId: ProjectId) =
       lens(_.schemas(on(schemaId)).projects(on(projectId)).main)
 
+    def compiler(schemaId: SchemaId, projectId: ProjectId) =
+      lens(_.schemas(on(schemaId)).projects(on(projectId)).compiler)
+
     def module(schemaId: SchemaId, projectId: ProjectId, moduleId: ModuleId) =
       lens(_.schemas(on(schemaId)).projects(on(projectId)).modules(on(moduleId)))
 

--- a/src/core/tables.scala
+++ b/src/core/tables.scala
@@ -164,7 +164,8 @@ case class Tables(config: Config) {
       Heading("PROJECT", _.id),
       Heading("MODULES", p => bar(p.modules.size)),
       Heading("DESC", _.description),
-      Heading("LICENSE", _.license)
+      Heading("LICENSE", _.license),
+      Heading("COMPILER", _.compiler)
   )
 
   def repositories(layout: Layout): Tabulation[SourceRepo] = Tabulation(


### PR DESCRIPTION
Also fixes a problem with modules hashing to the same value if they only differ in their source directories.

The behavior for default projects is:
- if a project has a default compiler, new modules created in that project will default to that compiler
- if a project does not have a default compiler specified, the first new module added with a compiler specified will set the default project compiler too
- a project's default compiler can be set manually