### PR TITLE
Support running JMH benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ dist/bundle/bin/coursier: dist/bundle/bin/.dir
 	chmod +x $@
 
 jmh-jars: dist/bundle/bin/coursier
-	for JAR in $(shell dist/bundle/bin/coursier fetch dist/bundle/lib org.openjdk.jmh:jmh-core:1.21 org.openjdk.jmh:jmh-generator-bytecode:1.21 org.openjdk.jmh:jmh-generator-reflection:1.21 org.openjdk.jmh:jmh-generator-asm:1.21); do \
+	for JAR in $(shell dist/bundle/bin/coursier fetch org.openjdk.jmh:jmh-core:1.21 org.openjdk.jmh:jmh-generator-bytecode:1.21 org.openjdk.jmh:jmh-generator-reflection:1.21 org.openjdk.jmh:jmh-generator-asm:1.21); do \
 		cp $$JAR dist/bundle/lib/ ; \
 	done
 
@@ -153,6 +153,7 @@ clean-dist:
 clean: clean-dist
 	rm -rf bootstrap/bin/fury
 	rm -rf bootstrap
+	rm -rf .bloop
 
 download: $(REPOS) dist/bundle/bin/coursier dist/bundle/bin/ng dist/bundle/bin/launcher dist/bundle/lib/$(NAILGUNJAR) bootstrap/scala
 	dist/bundle/bin/launcher --skip-bsp-connection $(BLOOPVERSION) # to download bloop

--- a/etc/bloop/fury.json
+++ b/etc/bloop/fury.json
@@ -32,7 +32,14 @@
       "$ROOT/bootstrap/scala/lib/scala-library.jar",
       "$ROOT/bootstrap/scala/lib/scala-compiler.jar",
       "$ROOT/bootstrap/scala/lib/scala-reflect.jar",
-      "$ROOT/dist/bundle/lib/nailgun-server-1.0.0.jar"
+      "$ROOT/dist/bundle/lib/nailgun-server-1.0.0.jar",
+      "$ROOT/dist/bundle/lib/jmh-core-1.21.jar",
+      "$ROOT/dist/bundle/lib/asm-5.0.3.jar",
+      "$ROOT/dist/bundle/lib/commons-math3-3.2.jar",
+      "$ROOT/dist/bundle/lib/jmh-generator-reflection.jar",
+      "$ROOT/dist/bundle/lib/jmh-generator-asm.jar",
+      "$ROOT/dist/bundle/lib/jmh-generator-bytecode.jar",
+      "$ROOT/dist/bundle/lib/jopt-simple-4.6.jar"
     ],
     "out": "$ROOT/bootstrap/bloop/out",
     "classesDir": "$ROOT/bootstrap/bin",

--- a/etc/bloop/fury.json
+++ b/etc/bloop/fury.json
@@ -36,9 +36,9 @@
       "$ROOT/dist/bundle/lib/jmh-core-1.21.jar",
       "$ROOT/dist/bundle/lib/asm-5.0.3.jar",
       "$ROOT/dist/bundle/lib/commons-math3-3.2.jar",
-      "$ROOT/dist/bundle/lib/jmh-generator-reflection.jar",
-      "$ROOT/dist/bundle/lib/jmh-generator-asm.jar",
-      "$ROOT/dist/bundle/lib/jmh-generator-bytecode.jar",
+      "$ROOT/dist/bundle/lib/jmh-generator-reflection-1.21.jar",
+      "$ROOT/dist/bundle/lib/jmh-generator-asm-1.21.jar",
+      "$ROOT/dist/bundle/lib/jmh-generator-bytecode-1.21.jar",
       "$ROOT/dist/bundle/lib/jopt-simple-4.6.jar"
     ],
     "out": "$ROOT/bootstrap/bloop/out",

--- a/layer.fury
+++ b/layer.fury
@@ -58,7 +58,22 @@ schemas	default	id	default
 								hidden	false
 						params	
 						sources	src/core	src/core
-						binaries	
+						binaries	org.openjdk.jmh:jmh-core:1.21	binRepo	central
+								group	org.openjdk.jmh
+								artifact	jmh-core
+								version	1.21
+							org.openjdk.jmh:jmh-generator-asm:1.21	binRepo	central
+								group	org.openjdk.jmh
+								artifact	jmh-generator-asm
+								version	1.21
+							org.openjdk.jmh:jmh-generator-bytecode:1.21	binRepo	central
+								group	org.openjdk.jmh
+								artifact	jmh-generator-bytecode
+								version	1.21
+							org.openjdk.jmh:jmh-generator-reflection:1.21	binRepo	central
+								group	org.openjdk.jmh
+								artifact	jmh-generator-reflection
+								version	1.21
 						resources	
 						bloopSpec	None
 					dependency	id	dependency

--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -216,7 +216,8 @@ object BuildCli {
               io,
               compilation.allDependenciesGraph.mapValues(_.to[Set]),
               multiplexer.stream(50, Some(Tick)),
-              Map())(config.theme)
+              Map(),
+              false)(config.theme)
       t1 <- Success(System.currentTimeMillis - t0)
       _  <- ~io.println(s"Total time: ${if (t1 >= 10000) s"${t1 / 1000}s" else s"${t1}ms"}\n")
     } yield io.await(Await.result(future, duration.Duration.Inf).success)

--- a/src/core/args.scala
+++ b/src/core/args.scala
@@ -89,7 +89,10 @@ object Args {
   val CompareArg   = CliParam[SchemaId]('w', Symbol("with"), "specify a schema to compare with")
 
   val KindArg =
-    CliParam[Kind]('t', 'type, "Type of module (library, application, plugin, compiler)")
+    CliParam[Kind](
+        't',
+        'type,
+        "Type of module (library, application, plugin, compiler, benchmarks)")
 
   val VerboseArg = CliParam[Unit]('v', 'verbose, "Show more output")
   val VersionArg = CliParam[RefSpec]('V', 'version, "Git branch, tag or commit")

--- a/src/core/graph.scala
+++ b/src/core/graph.scala
@@ -59,12 +59,16 @@ object Graph {
             tail,
             if (state.contains(ref)) state else state.updated(ref, AlreadyCompiled))
       case StopCompile(ref, out, success) #:: tail =>
+        val trimmedOutput = out.trim
         live(
             true,
             io,
             graph,
             tail,
-            state.updated(ref, if (success) Successful(None) else Failed(out)))
+            state.updated(
+                ref,
+                if (success) Successful(if (trimmedOutput.isEmpty) None else Some(trimmedOutput))
+                else Failed(trimmedOutput)))
       case SkipCompile(ref) #:: tail =>
         live(true, io, graph, tail, state.updated(ref, Skipped))
       case Stream.Empty =>
@@ -76,7 +80,7 @@ object Graph {
             }
           case (ref, Successful(Some(out))) =>
             UserMsg { theme =>
-              (msg"Output from $ref:".string(theme) + "\n" + out.trim)
+              (msg"Output from $ref:".string(theme).trim + "\n" + out.trim)
             }
         }.foldLeft(msg"")(_ + _)
         io.println(Ansi.down(graph.size + 1)())

--- a/src/core/jmh.scala
+++ b/src/core/jmh.scala
@@ -1,0 +1,12 @@
+package fury
+
+import org.openjdk.jmh._
+import generators.bytecode._
+
+import scala.util._
+
+object Jmh {
+
+  def instrument(bytecode: Path, sources: Path, resources: Path): Try[Unit] =
+    Try(JmhBytecodeGenerator.main(Array(bytecode.value, sources.value, resources.value, "asm")))
+}

--- a/src/core/jmh.scala
+++ b/src/core/jmh.scala
@@ -4,9 +4,17 @@ import org.openjdk.jmh._
 import generators.bytecode._
 
 import scala.util._
+import java.io._
 
 object Jmh {
 
-  def instrument(bytecode: Path, sources: Path, resources: Path): Try[Unit] =
-    Try(JmhBytecodeGenerator.main(Array(bytecode.value, sources.value, resources.value, "asm")))
+  def instrument(bytecode: Path, sources: Path, resources: Path): Try[Unit] = {
+    val discard: OutputStream = _ => ()
+    val out                   = System.out
+    System.setOut(new PrintStream(discard))
+    val result = Try(
+        JmhBytecodeGenerator.main(Array(bytecode.value, sources.value, resources.value, "asm")))
+    System.setOut(out)
+    result
+  }
 }

--- a/src/core/layout.scala
+++ b/src/core/layout.scala
@@ -31,19 +31,20 @@ case class Layout(home: Path, pwd: Path, env: Environment) {
   private[this] val uniqueId: String = java.util.UUID.randomUUID().toString
   private[this] val userDir          = (home / ".furyrc").extant()
 
-  lazy val furyDir: Path      = (pwd / ".fury").extant()
-  lazy val historyDir: Path   = (furyDir / "history").extant()
-  lazy val bloopDir: Path     = (furyDir / "bloop").extant()
-  lazy val classesDir: Path   = (furyDir / "classes").extant()
-  lazy val analysisDir: Path  = (furyDir / "analysis").extant()
-  lazy val resourcesDir: Path = (furyDir / "resources").extant()
-  lazy val reposDir: Path     = (userDir / "repos").extant()
-  lazy val srcsDir: Path      = (userDir / "sources").extant()
-  lazy val logsDir: Path      = (furyDir / "logs").extant()
-  lazy val sharedDir: Path    = (furyDir / "build" / uniqueId).extant()
-  lazy val errorLogfile: Path = logsDir.extant() / s"$nowString-$uniqueId.log"
-  lazy val userConfig: Path   = userDir / "config.fury"
-  lazy val aliasesPath: Path  = userDir / "aliases"
+  lazy val furyDir: Path       = (pwd / ".fury").extant()
+  lazy val historyDir: Path    = (furyDir / "history").extant()
+  lazy val bloopDir: Path      = (furyDir / "bloop").extant()
+  lazy val classesDir: Path    = (furyDir / "classes").extant()
+  lazy val benchmarksDir: Path = (furyDir / "benchmarks").extant()
+  lazy val analysisDir: Path   = (furyDir / "analysis").extant()
+  lazy val resourcesDir: Path  = (furyDir / "resources").extant()
+  lazy val reposDir: Path      = (userDir / "repos").extant()
+  lazy val srcsDir: Path       = (userDir / "sources").extant()
+  lazy val logsDir: Path       = (furyDir / "logs").extant()
+  lazy val sharedDir: Path     = (furyDir / "build" / uniqueId).extant()
+  lazy val errorLogfile: Path  = logsDir.extant() / s"$nowString-$uniqueId.log"
+  lazy val userConfig: Path    = userDir / "config.fury"
+  lazy val aliasesPath: Path   = userDir / "aliases"
 
   def bloopConfig(digest: Digest): Path =
     bloopDir.extant() / s"${digest.encoded[Base64Url]}.json"
@@ -53,11 +54,17 @@ case class Layout(home: Path, pwd: Path, env: Environment) {
   def outputDir(digest: Digest): Path =
     (analysisDir / digest.encoded[Base64Url]).extant()
 
+  def benchmarksDir(digest: Digest): Path =
+    (benchmarksDir / digest.encoded[Base64Url]).extant()
+
   def classesDir(digest: Digest): Path =
     (classesDir / digest.encoded[Base64Url]).extant()
 
+  def resourcesDir(digest: Digest): Path =
+    (resourcesDir / digest.encoded[Base64Url]).extant()
+
   def manifestFile(digest: Digest): Path =
-    (resourcesDir / digest.encoded[Base64Url]).extant() / "manifest.mf"
+    resourcesDir(digest) / "manifest.mf"
 
   val shell = Shell(env)
 }

--- a/src/core/shell.scala
+++ b/src/core/shell.scala
@@ -37,13 +37,13 @@ case class Shell(environment: Environment) {
     layout.sharedDir.mkdir()
     implicit val defaultEnvironment: Environment =
       environment.append("SHARED", layout.sharedDir.value)
-    val policy =
+    val cmd =
       if (securePolicy)
-        List("-Djava.security.manager", "-Djava.security.policy=${policyFile.value}")
-      else Nil
+        sh"java -Djava.security.manager -Djava.security.policy=${policyFile.value} -Dfury.sharedDir=${layout.sharedDir.value} -cp ${classpath
+          .mkString(":")} $main"
+      else sh"java -Dfury.sharedDir=${layout.sharedDir.value} -cp ${classpath.mkString(":")} $main"
 
-    sh"java $policy -Dfury.sharedDir=${layout.sharedDir.value} -cp ${classpath.mkString(":")} $main"
-      .async(output(_), output(_))
+    cmd.async(output(_), output(_))
   }
 
   def javac(classpath: List[String], dest: String, sources: List[String]) =

--- a/src/core/tables.scala
+++ b/src/core/tables.scala
@@ -94,7 +94,7 @@ case class Tables(config: Config) {
         Heading("DEPENDENCIES", (m: Module) => m.after, width = FlexibleWidth)(
             refinedModuleDep(projectId)),
         Heading("SRCS", _.sources),
-        Heading("BINS", m => bar(m.binaries.size)),
+        Heading("BINS", m => bar(m.allBinaries.size)),
         Heading("COMPILER", _.compiler),
         Heading("TYPE", _.kind),
         Heading("PARAMS", m => bar(m.params.size))

--- a/src/module/module.scala
+++ b/src/module/module.scala
@@ -114,7 +114,7 @@ object ModuleCli {
                   cli <- cli.hint(MainArg)
                   cli <- cli.hint(PluginArg)
                 } yield cli
-              case None | Some(Library | Compiler) => ~cli
+              case None | Some(Benchmarks | Library | Compiler) => ~cli
             }
       invoc      <- cli.read()
       io         <- invoc.io()
@@ -127,7 +127,9 @@ object ModuleCli {
                          .to[List]
                          .sequence
                          .map(_.headOption)
-      module <- ~Module(moduleId, compiler = optCompilerRef.orElse(project.compiler).getOrElse(ModuleRef.JavaRef))
+      module <- ~Module(
+                   moduleId,
+                   compiler = optCompilerRef.orElse(project.compiler).getOrElse(ModuleRef.JavaRef))
       module <- ~invoc(KindArg).toOption.map { k =>
                  module.copy(kind = k)
                }.getOrElse(module)
@@ -220,7 +222,7 @@ object ModuleCli {
                 } yield cli
               case Some(Compiler) =>
                 for (cli <- cli.hint(BloopSpecArg)) yield cli
-              case None | Some(Library) =>
+              case None | Some(Library | Benchmarks) =>
                 ~cli
             }
       cli        <- cli.hint(ForceArg)

--- a/src/module/module.scala
+++ b/src/module/module.scala
@@ -291,7 +291,7 @@ object BinaryCli {
       raw     <- ~invoc(RawArg).isSuccess
       project <- optProject.ascribe(UnspecifiedProject())
       module  <- optModule.ascribe(UnspecifiedModule())
-      rows    <- ~module.binaries.to[List]
+      rows    <- ~module.allBinaries.to[List]
       schema  <- defaultSchema
       table   <- ~Tables(config).show(Tables(config).binaries, cli.cols, rows, raw)(identity)
       _ <- ~(if (!raw)

--- a/src/ogdl/fury/io/Path.scala
+++ b/src/ogdl/fury/io/Path.scala
@@ -129,6 +129,20 @@ case class Path(value: String) {
     }
   }
 
+  def findChildren(predicate: String => Boolean): Set[Path] = {
+    def search(dir: java.io.File): Set[java.io.File] = {
+      val fileSet = dir.listFiles.to[Set]
+      fileSet.filter(_.isDirectory).flatMap(search(_)) ++
+        fileSet.filter { f =>
+          !f.isDirectory && predicate(f.getName)
+        }
+    }
+
+    search(javaPath.toFile).map { f =>
+      Path(f.getAbsolutePath)
+    }
+  }
+
   def findSubdirsContaining(predicate: String => Boolean): Set[Path] =
     Option(javaPath.toFile.listFiles).map { files =>
       val found = if (files.exists { f =>


### PR DESCRIPTION
Introduces a `benchmarks` module type, which will compile, generate
`jmh` sources, compile those sources, then run the benchmarks as part of
the build.

Additionally, `benchmarks` modules should,
- be run isolated, while nothing else is running (not yet implemented)
- automatically include a dependency on `jmh-core` (not yet implemented)
- stream output to the console