### PR TITLE
Use BSP instead of calling bloop via CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,13 @@ dist/bundle/bin/coursier: dist/bundle/bin/.dir
 	curl -s -L -o $@ https://git.io/coursier
 	chmod +x $@
 
+jmh_jars=org.openjdk.jmh:jmh-core:1.21 org.openjdk.jmh:jmh-generator-bytecode:1.21 org.openjdk.jmh:jmh-generator-reflection:1.21 org.openjdk.jmh:jmh-generator-asm:1.21
+bsp_jars=org.scala-sbt.ipcsocket:ipcsocket:1.0.0 org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.6.0 ch.epfl.scala:bsp4j:2.0.0-M3
+coursier_jars=io.get-coursier:coursier_2.12:1.1.0-M12
+external_jars=$(jmh_jars) $(bsp_jars) $(coursier_jars)
+
 dependency-jars: dist/bundle/bin/coursier
-	for JAR in $(shell dist/bundle/bin/coursier fetch org.openjdk.jmh:jmh-core:1.21 org.openjdk.jmh:jmh-generator-bytecode:1.21 org.openjdk.jmh:jmh-generator-reflection:1.21 org.openjdk.jmh:jmh-generator-asm:1.21 io.get-coursier:coursier_2.12:1.1.0-M12); do \
+	for JAR in $(shell dist/bundle/bin/coursier fetch $(external_jars)); do \
 		cp $$JAR dist/bundle/lib/ ; \
 	done
 

--- a/etc/bloop/fury.json
+++ b/etc/bloop/fury.json
@@ -42,7 +42,11 @@
       "$ROOT/dist/bundle/lib/jopt-simple-4.6.jar",
       "$ROOT/dist/bundle/lib/coursier-cache_2.12-1.1.0-M12.jar",
       "$ROOT/dist/bundle/lib/coursier-core_2.12-1.1.0-M12.jar",
-      "$ROOT/dist/bundle/lib/coursier_2.12-1.1.0-M12.jar"
+      "$ROOT/dist/bundle/lib/coursier_2.12-1.1.0-M12.jar",
+      "$ROOT/dist/bundle/lib/bsp4j-2.0.0-M3.jar",
+      "$ROOT/dist/bundle/lib/ipcsocket-1.0.0.jar",
+      "$ROOT/dist/bundle/lib/org.eclipse.lsp4j.jsonrpc-0.6.0.jar",
+      "$ROOT/dist/bundle/lib/gson-2.7.jar"
     ],
     "out": "$ROOT/bootstrap/bloop/out",
     "classesDir": "$ROOT/bootstrap/bin",

--- a/etc/fury
+++ b/etc/fury
@@ -16,6 +16,7 @@ cleanup() {
 
 nailgun() {
   "${FURYHOME}"/bin/ng --nailgun-port "$PORT" "$@"
+  cleanup
 }
 
 coursier(){

--- a/etc/fury
+++ b/etc/fury
@@ -16,11 +16,13 @@ cleanup() {
 
 nailgun() {
   if ! sh -c "${FURYHOME}/bin/ng --nailgun-version > /dev/null 2>&1" || [[ "1" -eq "$USE_NG_PY" ]] ; then 
-	"${FURYHOME}"/bin/ng.py --nailgun-port "$PORT" "$1" -- "${@:2}"
+      "${FURYHOME}"/bin/ng.py --nailgun-port "$PORT" "$1" -- "${@:2}"
   else
-	"${FURYHOME}"/bin/ng --nailgun-port "$PORT" "$1" "${@:2}"
+      "${FURYHOME}"/bin/ng --nailgun-port "$PORT" "$1" "${@:2}"
   fi
+  res=$?
   cleanup
+  return $res
 }
 
 

--- a/etc/security/fury_application_module.policy
+++ b/etc/security/fury_application_module.policy
@@ -2,7 +2,5 @@ grant {
       permission java.io.FilePermission "${fury.sharedDir}${/}-", "read,write";
       permission java.lang.RuntimePermission "getenv.SHARED", "read";
       permission java.util.PropertyPermission "fury.sharedDir", "read";
-      permission java.util.PropertyPermission "scala.maven.version.number", "read";
-      permission java.util.PropertyPermission "scala.version.number", "read";
-      permission java.util.PropertyPermission "scala.copyright.string", "read";
+      permission java.util.PropertyPermission "scala.*", "read";
 };

--- a/layer.fury
+++ b/layer.fury
@@ -56,6 +56,10 @@ schemas	default	id	default
 								moduleId	core
 								intransitive	false
 								hidden	false
+							pyroclastic/core	projectId	pyroclastic
+								moduleId	core
+								intransitive	false
+								hidden	false
 						params	
 						sources	src/core	src/core
 						binaries	ch.epfl.scala:bsp4j:2.0.0-M3	binRepo	central
@@ -378,7 +382,7 @@ schemas	default	id	default
 			platform	id	platform
 				repo	git@github.com:propensive/platform.git
 				track	master
-				commit	9d22a69871581081e6148af08f1a88ab8854cb58
+				commit	a1f0cc3ff90cb669132db599c8f9eec3362550cf
 				local	None
 			probation	id	probation
 				repo	git@github.com:propensive/probation.git

--- a/layer.fury
+++ b/layer.fury
@@ -58,7 +58,11 @@ schemas	default	id	default
 								hidden	false
 						params	
 						sources	src/core	src/core
-						binaries	io.get-coursier:coursier_2.12:1.1.0-M12	binRepo	central
+						binaries	ch.epfl.scala:bsp4j:2.0.0-M3	binRepo	central
+								group	ch.epfl.scala
+								artifact	bsp4j
+								version	2.0.0-M3
+							io.get-coursier:coursier_2.12:1.1.0-M12	binRepo	central
 								group	io.get-coursier
 								artifact	coursier_2.12
 								version	1.1.0-M12
@@ -78,6 +82,10 @@ schemas	default	id	default
 								group	org.openjdk.jmh
 								artifact	jmh-generator-reflection
 								version	1.21
+							org.scala-sbt.ipcsocket:ipcsocket:1.0.0	binRepo	central
+								group	org.scala-sbt.ipcsocket
+								artifact	ipcsocket
+								version	1.0.0
 						resources	
 						bloopSpec	None
 					dependency	id	dependency

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -15,18 +15,34 @@
  */
 package fury
 
+import java.io.File
 import java.nio.file.Files
+import java.util.Collections
+import java.util.concurrent.{ExecutorService, Executors}
 
+import ch.epfl.scala.bsp4j.{
+  BuildClientCapabilities,
+  BuildServer,
+  CompileParams,
+  InitializeBuildParams,
+  _
+}
 import exoskeleton._
 import gastronomy._
 import kaleidoscope._
 import mercator._
+import org.eclipse.lsp4j.jsonrpc.Launcher
+import org.scalasbt.ipcsocket.UnixDomainSocket
+import com.google.gson.{Gson, JsonElement}
+import fury.Graph.{DiagnosticError, DiagnosticMessage}
 
 import scala.collection.immutable.{SortedSet, TreeSet}
 import scala.collection.mutable.HashMap
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.collection.JavaConverters._
 import scala.concurrent._
 import scala.util._
+import scala.concurrent.duration._
 
 object ManifestEntry {
   implicit val stringShow: StringShow[ManifestEntry] = _.key
@@ -253,6 +269,150 @@ case class Compilation(
       Set(layout.classesDir(hash(c.ref)), layout.resourcesDir(hash(c.ref)))
     } ++ classpath(ref, layout) + layout.classesDir(hash(ref)) + layout.resourcesDir(hash(ref))
 
+  case class BuildingClient(
+      multiplexer: Multiplexer[ModuleRef, CompileEvent],
+      hashes: Map[String, ModuleRef])
+      extends BuildClient {
+    override def onBuildShowMessage(params: ShowMessageParams): Unit = {}
+
+    override def onBuildLogMessage(params: LogMessageParams): Unit = {}
+
+    override def onBuildPublishDiagnostics(params: PublishDiagnosticsParams): Unit = {
+      val uri = new java.net.URI(params.getBuildTarget.getUri)
+      val hash =
+        uri.getRawQuery.split("=")(1)
+      val modref   = hashes(hash)
+      val fileName = new java.net.URI(params.getTextDocument.getUri).getRawPath
+      val diag     = params.getDiagnostics.asScala.head
+      val lineNum  = diag.getRange.getStart.getLine
+      val charNum  = diag.getRange.getStart.getCharacter
+      val codeLine = scala.io.Source.fromFile(fileName).getLines.toList(lineNum)
+      multiplexer(modref) = DiagnosticMsg(
+          modref,
+          DiagnosticError(
+              s"\n${fileName}:${lineNum + 1}:${charNum + 1}:error:${diag.getMessage}\n${codeLine}\n${" " * charNum}^\n "
+          ) // TODO: print it prettier
+      )
+    }
+    override def onBuildTargetDidChange(params: DidChangeBuildTarget): Unit = {}
+
+    override def onBuildTaskStart(params: TaskStartParams): Unit = {
+      val gson = new Gson()
+      val json = params.getData.asInstanceOf[JsonElement]
+      val report =
+        gson.fromJson[CompileTask](json, classOf[CompileTask])
+      val hash =
+        new java.net.URI(report.getTarget.getUri).getRawQuery.split("=")(1)
+      val modref = hashes(hash)
+      multiplexer(modref) = StartCompile(modref)
+    }
+
+    override def onBuildTaskProgress(params: TaskProgressParams): Unit = {}
+
+    override def onBuildTaskFinish(params: TaskFinishParams): Unit = {
+      val gson = new Gson()
+      params.getDataKind match {
+        case TaskDataKind.COMPILE_REPORT =>
+          val json = params.getData.asInstanceOf[JsonElement]
+          val report =
+            gson.fromJson[CompileReport](json, classOf[CompileReport])
+          val hash =
+            new java.net.URI(report.getTarget.getUri).getRawQuery.split("=")(1)
+          val modref = hashes(hash)
+          params.getStatus match {
+            case StatusCode.OK => {
+              multiplexer(modref) = StopCompile(modref, "", true)
+            }
+            case StatusCode.ERROR => {
+              multiplexer(modref) = StopCompile(modref, params.toString, false)
+            }
+            case StatusCode.CANCELLED => {
+              multiplexer(modref) = StopCompile(modref, params.toString, false)
+            }
+          }
+      }
+    }
+  }
+
+  def retry[T](duration: FiniteDuration)(f: => T): Try[T] =
+    try {
+      Success(f)
+    } catch {
+      case e: Exception =>
+        if (duration <= 0.milliseconds)
+          Failure(e)
+        else {
+          val period = 50.milliseconds
+          Thread.sleep(period.toMillis)
+          retry(duration - period)(f)
+        }
+    }
+
+  def using[A, B](resource: A)(cleanup: A => Unit)(f: A => B): B =
+    try {
+      f(resource)
+    } finally {
+      cleanup(resource)
+    }
+
+  def compileModule(
+      target: String,
+      layout: Layout,
+      multiplexer: Multiplexer[ModuleRef, CompileEvent],
+      hashes: Map[String, ModuleRef],
+      client: BuildingClient
+    ): Future[ch.epfl.scala.bsp4j.CompileResult] = Future {
+    val furyTempPath = Path.getTempDir("fury-socket-").get
+    val socketPath   = furyTempPath / "socket"
+    val process      = layout.shell.bloop.startBsp(socketPath.value)
+    using(retry(5 seconds) {
+      new UnixDomainSocket(socketPath.value)
+    }.get) { s =>
+      s.shutdownInput()
+      s.shutdownOutput()
+    } { bloopSocket =>
+      using(Executors.newCachedThreadPool())(_.shutdown()) { ex =>
+        val launcher = new Launcher.Builder[BuildServer]()
+          .setRemoteInterface(classOf[BuildServer])
+          .setExecutorService(ex)
+          .setInput(bloopSocket.getInputStream)
+          .setOutput(bloopSocket.getOutputStream)
+          .setLocalService(client)
+          .create()
+        val listening = launcher.startListening()
+        val server    = launcher.getRemoteProxy
+        val capabilities = new BuildClientCapabilities(
+            Collections.singletonList("scala")
+        )
+        (layout.furyDir / ".bloop").linksTo(Path("bloop"))
+        val initializeParams = new InitializeBuildParams(
+            "fury",
+            "1.0.0",
+            "2.0.0-M3",
+            new java.io.File(layout.furyDir.value).toURI.toString,
+            capabilities
+        )
+        server.buildInitialize(initializeParams).get
+        server.onBuildInitialized()
+        val targets = server.workspaceBuildTargets.get
+        targets.getTargets.asScala.find(_.getDisplayName == target) match {
+          case Some(target) =>
+            val cp                = new CompileParams(Collections.singletonList(target.getId))
+            val compilationResult = server.buildTargetCompile(cp).get
+            server
+              .workspaceBuildTargets()
+              .get() // TODO: some action must be done after build, otherwise bloop sometimes hang
+            compilationResult
+          case None =>
+            throw new RuntimeException(
+                s"Fatal error: target '${target}' not found in build targets ${targets.getTargets.asScala
+                  .map(_.getDisplayName)} of '${layout.furyDir}'")
+
+        }
+      }
+    }
+  }
+
   def compile(
       io: Io,
       moduleRef: ModuleRef,
@@ -269,68 +429,30 @@ case class Compilation(
       if (futures.contains(dep)) futures
       else compile(io, dep, multiplexer, futures, layout)
     }
-
     val dependencyFutures = Future.sequence(modulesToExecuteBloopGraph(moduleRef).map(newFutures))
-
     val future =
       dependencyFutures.flatMap { inputs =>
         if (inputs.exists(!_.success)) {
           multiplexer(artifact.ref) = SkipCompile(artifact.ref)
           multiplexer.close(artifact.ref)
           Future.successful(CompileResult(false, ""))
-        } else
-          Future {
-            val out           = new StringBuilder()
-            val noCompilation = artifact.sourcePaths.isEmpty
-
-            if (noCompilation) deepDependencies(artifact.ref).foreach { ref =>
-              multiplexer(ref) = NoCompile(ref)
-            }
-
-            val compileResult: Boolean =
-              noCompilation || blocking {
-                layout.shell.bloop
-                  .compile(hash(artifact.ref).encoded, configDir = layout.bloopDir) {
-                    (ln: String) =>
-                      {
-                        out.append(ln)
-                        out.append("\n")
-                        ln match {
-                          case r"Compiling $moduleHash@([a-zA-Z0-9\+\_\=\/]+).*" => {
-                            val ref = hashes(moduleHash)
-                            deepDependencies(ref).foreach { ref =>
-                              multiplexer(ref) = NoCompile(ref)
-                            }
-                            multiplexer(ref) = StartCompile(ref)
-                          }
-                          case r"Compiled $moduleHash@([a-zA-Z0-9\+\_\=\/]+).*" => {
-                            val ref = hashes(moduleHash)
-                            deepDependencies(ref).foreach { ref =>
-                              multiplexer(ref) = NoCompile(ref)
-                            }
-                            multiplexer(hashes(moduleHash)) =
-                              StopCompile(hashes(moduleHash), "", true)
-                            multiplexer.close(hashes(moduleHash))
-                          }
-                          case r".*'$moduleHash@([a-zA-Z0-9\+\_\=\/]+)' failed to compile.*" => {
-                            out.append(s"Failed to compile '${hashes(moduleHash)}'\n")
-                            val ref = hashes(moduleHash)
-                            deepDependencies(ref).foreach { ref =>
-                              multiplexer(ref) = NoCompile(ref)
-                            }
-                            multiplexer(hashes(moduleHash)) =
-                              StopCompile(hashes(moduleHash), out.toString(), false)
-                            out.clear()
-                          }
-                          case _ => ()
-                        }
-                      }
-                  }
-                  .await() == 0
-              }
-
-            val finalResult =
-              if (compileResult && (artifact.kind == Application || artifact.kind == Benchmarks)) {
+        } else {
+          val out           = new StringBuilder()
+          val noCompilation = artifact.sourcePaths.isEmpty
+          if (noCompilation) deepDependencies(artifact.ref).foreach { ref =>
+            multiplexer(ref) = NoCompile(ref)
+          }
+          val targetHash = hash(artifact.ref).encoded
+          blocking {
+            compileModule(
+                targetHash,
+                layout,
+                multiplexer,
+                hashes,
+                BuildingClient(multiplexer, hashes)).map(_.getStatusCode == StatusCode.OK)
+          }.map { compileResult =>
+// inserted
+                          if (compileResult && (artifact.kind == Application || artifact.kind == Benchmarks)) {
                 multiplexer(artifact.ref) = StartStreaming
                 if (artifact.kind == Benchmarks) {
                   Jmh.instrument(
@@ -372,15 +494,42 @@ case class Compilation(
                 res
               } else compileResult
 
-            CompileResult(finalResult, out.toString)
-          }
-      }
+// end inserted
 
+          }.map(CompileResult(_, out.toString))
+        }
+      }
     newFutures.updated(artifact.ref, future)
   }
 
+  private def executeApplicationModule(
+      io: Io,
+      multiplexer: Multiplexer[ModuleRef, CompileEvent],
+      layout: Layout,
+      artifact: Artifact,
+      out: StringBuilder
+    ) = {
+    val res = layout.shell
+      .runJava(
+          runtimeClasspath(io, artifact.ref, layout).to[List].map(_.value),
+          artifact.main.getOrElse(""),
+          true,
+          layout
+      ) { ln =>
+        out.append(ln)
+        out.append("\n")
+      }
+      .await() == 0
+    if (!res) {
+      deepDependencies(artifact.ref).foreach { ref =>
+        multiplexer(ref) = NoCompile(ref)
+      }
+      multiplexer(artifact.ref) = StopCompile(artifact.ref, out.toString, false)
+      multiplexer.close(artifact.ref)
+    }
+    res
+  }
 }
-
 case class Entity(project: Project, schema: Schema, path: Path)
 
 /** A Universe represents a the fully-resolved set of projects available in the layer */
@@ -979,6 +1128,7 @@ case class SkipCompile(ref: ModuleRef)                                   extends
 case class Print(line: String)                                           extends CompileEvent
 object StartStreaming                                                    extends CompileEvent
 object StopStreaming                                                     extends CompileEvent
+case class DiagnosticMsg(ref: ModuleRef, msg: DiagnosticMessage)         extends CompileEvent
 
 case class CompileResult(success: Boolean, output: String)
 

--- a/src/core/shell.scala
+++ b/src/core/shell.scala
@@ -178,7 +178,7 @@ case class Shell(environment: Environment) {
     private val defaultConfigDir = Path(".fury") / "bloop"
 
     def start(): Running =
-      sh"sh -c 'launcher 1.2.5 > /dev/null'".async(_ => (), _ => ())
+      sh"sh -c 'launcher --skip-bsp-connection 1.2.5 > /dev/null'".async(_ => (), _ => ())
 
     def running(): Boolean =
       sh"bloop help".exec[Exit[String]].status == 0

--- a/src/core/shell.scala
+++ b/src/core/shell.scala
@@ -189,6 +189,8 @@ case class Shell(environment: Environment) {
     def compile(name: String, configDir: Path = defaultConfigDir)(output: String => Unit): Running =
       sh"bloop compile $name --config-dir ${configDir.value}".async(output(_), output(_))
 
+    def startBsp(socket: String): Running =
+      sh"bloop bsp --socket $socket".async(println(_), _ => ())
   }
 
   object java {

--- a/src/ogdl/fury/io/Path.scala
+++ b/src/ogdl/fury/io/Path.scala
@@ -35,6 +35,10 @@ object Path {
       Some(Path(if (dir.endsWith("/")) dir.dropRight(1) else dir))
     case _ => None
   }
+
+  def getTempDir(prefix: String): Try[Path] =
+    Try { Path(Files.createTempDirectory(prefix).toString) }
+
 }
 
 case class Path(value: String) {
@@ -237,6 +241,15 @@ case class Path(value: String) {
       java.nio.file.Files.createDirectories(parent.javaPath)
       this
     }
+
+  def linksTo(target: Path): Try[Path] =
+    Try {
+      Files.createSymbolicLink(javaPath, target.javaPath)
+      this
+    }.recover {
+      case e: java.io.IOException => this
+    }
+
 }
 
 case class FileNotFound(path: Path)      extends FuryException

--- a/src/strings/colors.scala
+++ b/src/strings/colors.scala
@@ -86,8 +86,8 @@ object Theme {
           license = Rgb(160, 160, 170),
           binary = Rgb(100, 200, 200),
           gray = Rgb(80, 80, 80),
-          success = Rgb(0, 200, 0),
-          ongoing = Rgb(0, 0, 200),
+          success = Rgb(40, 150, 40),
+          ongoing = Rgb(150, 120, 0),
           failure = Rgb(200, 0, 0))
 
   object Basic
@@ -107,7 +107,7 @@ object Theme {
           binary = Ansi.brightCyan,
           gray = Ansi.brightBlack,
           success = Ansi.green,
-          ongoing = Ansi.blue,
+          ongoing = Ansi.yellow,
           failure = Ansi.red)
 
   object NoColor extends Theme("nocolor") {

--- a/src/strings/colors.scala
+++ b/src/strings/colors.scala
@@ -87,6 +87,7 @@ object Theme {
           binary = Rgb(100, 200, 200),
           gray = Rgb(80, 80, 80),
           success = Rgb(0, 200, 0),
+          ongoing = Rgb(0, 0, 200),
           failure = Rgb(200, 0, 0))
 
   object Basic
@@ -106,6 +107,7 @@ object Theme {
           binary = Ansi.brightCyan,
           gray = Ansi.brightBlack,
           success = Ansi.green,
+          ongoing = Ansi.blue,
           failure = Ansi.red)
 
   object NoColor extends Theme("nocolor") {
@@ -136,6 +138,7 @@ case class Theme(
     binary: AnsiCode = AnsiCode(""),
     gray: AnsiCode = AnsiCode(""),
     success: AnsiCode = AnsiCode(""),
+    ongoing: AnsiCode = AnsiCode(""),
     failure: AnsiCode = AnsiCode("")) {
   val reset: AnsiCode     = AnsiCode("0m")
   val bold: AnsiCode      = AnsiCode("1m")


### PR DESCRIPTION
Known limiations that will be fixed in future:

1. New BSP connection is established and destroyed each time, what is not optimal.
2. Build progress messages are unused
3. Error messages printing implementation is absolutely minimal - requires much more focus.
4. After BSP "buildTargetCompile" module is called, the
"workspaceBuildTargets" request is sent. Without it, bloop sometimes hang.