### PR TITLE
Use separate working dirs for every module

### DIFF
--- a/src/core/bloop.scala
+++ b/src/core/bloop.scala
@@ -89,7 +89,7 @@ object Bloop {
           version = "1.0.0",
           project = Json(
               name = compilation.hash(artifact.ref).encoded[Base64Url],
-              directory = layout.base.value,
+              directory = layout.workDir(compilation.hash(artifact.ref)).value,
               sources = artifact.sourcePaths.map(_.value),
               dependencies = compilation
                 .allDependenciesGraph(artifact.ref)

--- a/src/core/layout.scala
+++ b/src/core/layout.scala
@@ -62,6 +62,7 @@ case class Layout(home: Path, pwd: Path, env: Environment, base: Path) {
   lazy val reposDir: Path      = (userDir / "repos").extant()
   lazy val srcsDir: Path       = (userDir / "sources").extant()
   lazy val logsDir: Path       = (furyDir / "logs").extant()
+  lazy val workDir: Path       = (furyDir / "work").extant()
   lazy val sharedDir: Path     = (furyDir / "build" / uniqueId).extant()
   lazy val errorLogfile: Path  = logsDir.extant() / s"$nowString-$uniqueId.log"
   lazy val userConfig: Path    = userDir / "config.fury"
@@ -74,6 +75,9 @@ case class Layout(home: Path, pwd: Path, env: Environment, base: Path) {
 
   def outputDir(digest: Digest): Path =
     (analysisDir / digest.encoded[Base64Url]).extant()
+
+  def workDir(digest: Digest): Path =
+    (workDir / digest.encoded[Base64Url]).extant()
 
   def benchmarksDir(digest: Digest): Path =
     (benchmarksDir / digest.encoded[Base64Url]).extant()


### PR DESCRIPTION
This might fix the problem where the `classes.bak` directory has a name
clash because two or more bloop processes are working on it
concurrently.