### PR TITLE
Simplify bsp session creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ dist/bundle/bin/coursier: dist/bundle/bin/.dir
 	chmod +x $@
 
 jmh_jars=org.openjdk.jmh:jmh-core:1.21 org.openjdk.jmh:jmh-generator-bytecode:1.21 org.openjdk.jmh:jmh-generator-reflection:1.21 org.openjdk.jmh:jmh-generator-asm:1.21
-bsp_jars=org.scala-sbt.ipcsocket:ipcsocket:1.0.0 org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.6.0 ch.epfl.scala:bsp4j:2.0.0-M3
+bsp_jars=org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.6.0 ch.epfl.scala:bsp4j:2.0.0-M3
 coursier_jars=io.get-coursier:coursier_2.12:1.1.0-M12
 external_jars=$(jmh_jars) $(bsp_jars) $(coursier_jars)
 

--- a/src/core/bloop.scala
+++ b/src/core/bloop.scala
@@ -30,11 +30,13 @@ object Bloop {
   private[this] def testServer(): Try[Unit] =
     Try(new Socket("localhost", 8212).close().unit)
 
+  def version: String = "1.2.5"
+
   def server(shell: Shell, io: Io): Try[Running] =
     synchronized {
       val interval = 150.millis
       io.print("Launching bloop compile server...")
-      val running = shell.bloop.start()
+      val running = shell.bloop.start(version)
       Stream
         .iterate[(Try[Unit], Duration)]((testServer, 5 seconds)) {
           case (Success(()), _) => Success(()) -> (0 seconds)

--- a/src/core/shell.scala
+++ b/src/core/shell.scala
@@ -177,8 +177,8 @@ case class Shell(environment: Environment) {
   object bloop {
     private val defaultConfigDir = Path(".fury") / "bloop"
 
-    def start(): Running =
-      sh"sh -c 'launcher --skip-bsp-connection 1.2.5 > /dev/null'".async(_ => (), _ => ())
+    def start(version: String): Running =
+      sh"sh -c 'launcher --skip-bsp-connection ${version} > /dev/null'".async(_ => (), _ => ())
 
     def running(): Boolean =
       sh"bloop help".exec[Exit[String]].status == 0


### PR DESCRIPTION
1. Use launcher's std i/o
2. Remove dependency on ipcsocket
3. Remove ugly hack with "workspaceBuildTargets" call
4. Still no session caching