### PR TITLE
Print all diagnostics

### DIFF
--- a/src/core/graph.scala
+++ b/src/core/graph.scala
@@ -30,9 +30,8 @@ object Graph {
   sealed trait DiagnosticMessage {
     def msg: String
   }
-  case class DiagnosticError(msg: String)   extends DiagnosticMessage
-  case class DiagnosticWarning(msg: String) extends DiagnosticMessage
-  case class OtherMessage(msg: String)      extends DiagnosticMessage
+  case class CompilerDiagnostic(msg: String) extends DiagnosticMessage
+  case class OtherMessage(msg: String)       extends DiagnosticMessage
 
   case class CompilationInfo(state: CompileState, messages: List[DiagnosticMessage])
 


### PR DESCRIPTION
Bloop sends a few diagnostic msgs at once.
Previously only the first from a list was taken.