### PR TITLE
WIP: Bsp server support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ dist/bundle/bin/coursier: dist/bundle/bin/.dir
 	chmod +x $@
 
 jmh_jars=org.openjdk.jmh:jmh-core:1.21 org.openjdk.jmh:jmh-generator-bytecode:1.21 org.openjdk.jmh:jmh-generator-reflection:1.21 org.openjdk.jmh:jmh-generator-asm:1.21
-bsp_jars=org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.6.0 ch.epfl.scala:bsp4j:2.0.0-M3
+bsp_jars=org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.6.0 ch.epfl.scala:bsp4j:2.0.0-M4
 coursier_jars=io.get-coursier:coursier_2.12:1.1.0-M12
 external_jars=$(jmh_jars) $(bsp_jars) $(coursier_jars)
 

--- a/etc/bloop/fury.json
+++ b/etc/bloop/fury.json
@@ -43,7 +43,7 @@
       "$ROOT/dist/bundle/lib/coursier-cache_2.12-1.1.0-M12.jar",
       "$ROOT/dist/bundle/lib/coursier-core_2.12-1.1.0-M12.jar",
       "$ROOT/dist/bundle/lib/coursier_2.12-1.1.0-M12.jar",
-      "$ROOT/dist/bundle/lib/bsp4j-2.0.0-M3.jar",
+      "$ROOT/dist/bundle/lib/bsp4j-2.0.0-M4.jar",
       "$ROOT/dist/bundle/lib/ipcsocket-1.0.0.jar",
       "$ROOT/dist/bundle/lib/org.eclipse.lsp4j.jsonrpc-0.6.0.jar",
       "$ROOT/dist/bundle/lib/gson-2.7.jar",

--- a/etc/bloop/fury.json
+++ b/etc/bloop/fury.json
@@ -46,7 +46,10 @@
       "$ROOT/dist/bundle/lib/bsp4j-2.0.0-M3.jar",
       "$ROOT/dist/bundle/lib/ipcsocket-1.0.0.jar",
       "$ROOT/dist/bundle/lib/org.eclipse.lsp4j.jsonrpc-0.6.0.jar",
-      "$ROOT/dist/bundle/lib/gson-2.7.jar"
+      "$ROOT/dist/bundle/lib/gson-2.7.jar",
+      "$ROOT/dist/bundle/lib/coursier-cache_2.12-1.1.0-M12.jar",
+      "$ROOT/dist/bundle/lib/coursier-core_2.12-1.1.0-M12.jar",
+      "$ROOT/dist/bundle/lib/coursier_2.12-1.1.0-M12.jar"
     ],
     "out": "$ROOT/bootstrap/bloop/out",
     "classesDir": "$ROOT/bootstrap/bin",

--- a/etc/fury
+++ b/etc/fury
@@ -67,7 +67,7 @@ startFuryStandalone() {
 
 startFuryDirect() {
   SCALA=$(coursier fetch --classpath org.scala-lang:scala-reflect:2.12.8 com.facebook:nailgun-server:1.0.0)
-  java -Dfury.home="${FURYHOME}" -cp "$SCALA:$CLASSPATH" -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:25005 "$FURY_MAIN" "$@"
+  java -Dfury.home="${FURYHOME}" -cp "$SCALA:$CLASSPATH" -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=127.0.0.1:25005 "$FURY_MAIN" "$@"
 }
 
 case "$1" in

--- a/etc/fury
+++ b/etc/fury
@@ -65,12 +65,20 @@ startFuryStandalone() {
   java -Dfury.home="${FURYHOME}" -cp "$SCALA:$CLASSPATH" "$MAIN" "$PORT"
 }
 
+startFuryDirect() {
+  SCALA=$(coursier fetch --classpath org.scala-lang:scala-reflect:2.12.8 com.facebook:nailgun-server:1.0.0)
+  java -Dfury.home="${FURYHOME}" -cp "$SCALA:$CLASSPATH" "$FURY_MAIN" "$@"
+}
+
 case "$1" in
   "start")
     startFury
     ;;
   "standalone")
     startFuryStandalone
+    ;;
+  "direct")
+    startFuryDirect "${@:2}"
     ;;
   "kill")
     killFury

--- a/etc/fury
+++ b/etc/fury
@@ -67,7 +67,7 @@ startFuryStandalone() {
 
 startFuryDirect() {
   SCALA=$(coursier fetch --classpath org.scala-lang:scala-reflect:2.12.8 com.facebook:nailgun-server:1.0.0)
-  java -Dfury.home="${FURYHOME}" -cp "$SCALA:$CLASSPATH" "$FURY_MAIN" "$@"
+  java -Dfury.home="${FURYHOME}" -cp "$SCALA:$CLASSPATH" -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:25005 "$FURY_MAIN" "$@"
 }
 
 case "$1" in

--- a/layer.fury
+++ b/layer.fury
@@ -62,10 +62,10 @@ schemas	default	id	default
 								hidden	false
 						params	
 						sources	src/core	src/core
-						binaries	ch.epfl.scala:bsp4j:2.0.0-M3	binRepo	central
+						binaries	ch.epfl.scala:bsp4j:2.0.0-M4	binRepo	central
 								group	ch.epfl.scala
 								artifact	bsp4j
-								version	2.0.0-M3
+								version	2.0.0-M4
 							io.get-coursier:coursier_2.12:1.1.0-M12	binRepo	central
 								group	io.get-coursier
 								artifact	coursier_2.12

--- a/src/core/bloop.scala
+++ b/src/core/bloop.scala
@@ -21,15 +21,9 @@ import gastronomy._
 import guillotine._
 import mercator._
 
+import scala.concurrent.duration._
 import scala.util._
 import scala.util.control.NonFatal
-import scala.concurrent.duration._
-
-import ch.epfl.scala.bsp4j._
-import org.eclipse.lsp4j.jsonrpc.Launcher
-import java.util.concurrent.Executors
-import org.scalasbt.ipcsocket.UnixDomainSocket
-import scala.collection.JavaConverters._
 
 object Bloop {
 

--- a/src/core/bloop.scala
+++ b/src/core/bloop.scala
@@ -25,6 +25,12 @@ import scala.util._
 import scala.util.control.NonFatal
 import scala.concurrent.duration._
 
+import ch.epfl.scala.bsp4j._
+import org.eclipse.lsp4j.jsonrpc.Launcher
+import java.util.concurrent.Executors
+import org.scalasbt.ipcsocket.UnixDomainSocket
+import scala.collection.JavaConverters._
+
 object Bloop {
 
   private[this] def testServer(): Try[Unit] =

--- a/src/core/bsp.scala
+++ b/src/core/bsp.scala
@@ -16,25 +16,31 @@
 package fury
 
 import java.io.{InputStream, OutputStream}
+import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, StandardOpenOption}
-import java.util.Collections
 import java.util.concurrent.{CompletableFuture, Future}
 
 import ch.epfl.scala.bsp4j
 import ch.epfl.scala.bsp4j._
+import fury.FuryBuildServer._
+import gastronomy.{Bytes, Digest, Md5}
+import mercator._
 import org.eclipse.lsp4j.jsonrpc.Launcher
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
 
-
 object Bsp {
+
+  val bspVersion = "2.0.0"
 
   def createConfig(ctx: BspCli.Context): Try[ExitStatus] = {
     val bspDir = ctx.layout.bspDir.extant()
     val bspConfig = bspDir / "fury.json"
-    val write = for {
+
+    for {
       configFile <- ~Files.write(
         bspConfig.javaPath,
         bspConfigJson(ctx).serialize.getBytes(StandardCharsets.UTF_8),
@@ -43,12 +49,6 @@ object Bsp {
     } yield {
       println(s"BSP config written to $configFile")
       Done
-    }
-
-    write.recover {
-      case err: Throwable =>
-        err.printStackTrace(System.err)
-        Abort
     }
   }
 
@@ -62,37 +62,27 @@ object Bsp {
         furyExecutable.javaPath.toAbsolutePath.toString,
         "direct", "bsp", "run"
       ),
-      version = "0.4.0-dev",
-      bspVersion = "2.0",
+      version = Version.current,
+      bspVersion = bspVersion,
       languages = List("java","scala")
     )
   }
 
   def startServer(ctx: BspCli.Context): Try[ExitStatus] = {
-    val waiting = for {
+    for {
       running <- ~run(System.in, System.out, ctx.layout)
     } yield {
       System.err.println("started bsp process ...")
       running.get()
+      Done
     }
-
-    waiting
-      .map { _ =>
-        System.err.println("completed bsp process")
-        Done
-      }
-      .recover {
-        case err: Throwable =>
-          System.err.println(s"bsp process encountered problem: ${err.getMessage}")
-          err.printStackTrace(System.err)
-          Abort
-      }
   }
 
 
   def run(in: InputStream, out: OutputStream, layout: Layout): Future[Void] = {
 
-    val server = new FuryBuildServer(layout)
+    val cancel = new Cancelator()
+    val server = new FuryBuildServer(layout, cancel)
 
     val launcher = new Launcher.Builder[BuildClient]()
       .setRemoteInterface(classOf[BuildClient])
@@ -103,7 +93,9 @@ object Bsp {
 
     server.onConnectWithClient(launcher.getRemoteProxy)
 
-    launcher.startListening()
+    val listening = launcher.startListening()
+    cancel.cancel = () => listening.cancel(true) // YOLO
+    listening
   }
 
 }
@@ -112,18 +104,45 @@ object BspCli {
   case class Context(cli: Cli[CliParam[_]], layout: Layout)
 
   def context(cli: Cli[CliParam[_]]): Try[Context] =
-    for {
-      layout <- cli.layout
-    } yield Context(cli, layout)
+    cli.layout.map(Context(cli, _))
 }
 
-class FuryBuildServer(layout: Layout) extends BuildServer {
+class FuryBuildServer(layout: Layout, cancel: Cancelator) extends BuildServer with ScalaBuildServer {
   import FuryBuildServer._
 
+  private val config = Config()
+  private val io = new Io(System.err, config)
+
+  private def structure: Try[Structure] =
+    for {
+      layer <- Layer.read(io, layout.furyConfig, layout)
+      schema <- layer.mainSchema
+      hierarchy <- schema.hierarchy(io, layout.pwd, layout)
+      universe <- hierarchy.universe
+      projects <- layer.projects
+      graph <- projects.flatMap(_.moduleRefs).map { ref =>
+        for {
+          ds <- universe.dependencies(io, ref, layout)
+          arts <- (ds + ref).map { d => universe.artifact(io, d, layout) }.sequence
+        } yield {
+          arts.map { a => (a.ref, a.dependencies ++ a.compiler.map(_.ref.hide)) }
+        }
+      }.sequence.map(_.flatten.toMap)
+      allModuleRefs = graph.keys
+      modules <- allModuleRefs.traverse(ref => universe.getMod(ref).map((ref, _)))
+      artifacts <- graph.keys.map { key =>
+        universe.artifact(io, key, layout).map(key -> _)
+      }.sequence.map(_.toMap)
+      checkouts <- graph.keys.map(universe.checkout(_, layout)).sequence
+    } yield Structure(
+      modules.toMap,
+      graph,
+      checkouts.foldLeft(Set[Checkout]())(_ ++ _),
+      artifacts)
 
   override def buildInitialize(initializeBuildParams: InitializeBuildParams): CompletableFuture[InitializeBuildResult] = {
 
-    System.err.println("**> buildInitialize")
+    io.println("**> buildInitialize")
 
     val capabilities = new BuildServerCapabilities()
     capabilities.setBuildTargetChangedProvider(false)
@@ -137,7 +156,7 @@ class FuryBuildServer(layout: Layout) extends BuildServer {
     val testProvider = new TestProvider(List.empty[String].asJava) // fury does not yet have a dedicated test interface
     capabilities.setTestProvider(testProvider)
 
-    val result = new InitializeBuildResult("Fury", "0.4.0-dev", "2.0.0", capabilities)
+    val result = new InitializeBuildResult("Fury", Version.current, Bsp.bspVersion, capabilities)
     val future = new CompletableFuture[InitializeBuildResult]()
     future.complete(result)
     future
@@ -148,35 +167,26 @@ class FuryBuildServer(layout: Layout) extends BuildServer {
   }
 
   override def onBuildExit(): Unit = {
-    // TODO
+    io.println("**> buildExit")
+    cancel.cancel() // YOLO?
   }
 
   override def buildShutdown(): CompletableFuture[AnyRef] = {
-    System.err.println("**> buildShutdown")
-    // TODO
+    io.println("**> buildShutdown")
     val result = new CompletableFuture[AnyRef]()
-    result.complete("shutdown elided") // FIXME ensure shutdown
+    result.complete("just exit already")
     result
   }
 
   override def workspaceBuildTargets(): CompletableFuture[WorkspaceBuildTargetsResult] = {
 
-    System.err.println("**> workspaceBuildTargets")
-
-    val config = Config()
-    val io = new Io(System.out, config)
+    io.println("**> workspaceBuildTargets")
 
     val result = for {
-      layer <- Layer.read(io, layout.furyConfig, layout)
-      projects <- layer.projects
+      struct <- structure
     } yield {
-      // TODO respect current schema
-      val targets = projects
-        .flatMap(_.modules)
-        .map(moduletoTarget)
-        .toList
-
-      new WorkspaceBuildTargetsResult(targets.asJava)
+      val targets = struct.artifacts.values.map(artifactToTarget(_, struct))
+      new WorkspaceBuildTargetsResult(targets.toList.asJava)
     }
 
     val future = new CompletableFuture[WorkspaceBuildTargetsResult]()
@@ -191,78 +201,218 @@ class FuryBuildServer(layout: Layout) extends BuildServer {
 
   override def buildTargetSources(sourcesParams: SourcesParams): CompletableFuture[SourcesResult] = {
 
-    System.err.println("**> buildTargetSources")
+    io.println("**> buildTargetSources")
 
-    // TODO get sources for modules corresponding to targets
-    val res = new SourcesResult(Collections.emptyList())
+    val sourceItems = for {
+      struct <- structure
+      targets = sourcesParams.getTargets.asScala
+      items <- targets.traverse { t =>
+        struct.moduleRef(t).map { ref =>
+          artifactSourcesItem(t, struct.artifacts(ref))
+        }
+      }
+    } yield new SourcesResult(items.asJava)
+
     val future = new CompletableFuture[SourcesResult]()
-    future.complete(res)
+    sourceItems match {
+      case Success(value) => future.complete(value)
+      case Failure(exception) => future.completeExceptionally(exception)
+    }
+
     future
   }
 
+  private def artifactSourcesItem(target: BuildTargetIdentifier, a: Artifact): SourcesItem = {
+    val items = a.sourcePaths.map { p =>
+      new SourceItem(p.javaPath.toUri.toString, SourceItemKind.DIRECTORY, false)
+    }
+    new SourcesItem(target, items.asJava)
+  }
+
+
   override def buildTargetInverseSources(inverseSourcesParams: InverseSourcesParams): CompletableFuture[InverseSourcesResult] = {
-    // TODO
-    val result = new CompletableFuture[InverseSourcesResult]()
-    result.completeExceptionally(new NotImplementedError("method not implemented"))
-    result
+    val future = new CompletableFuture[InverseSourcesResult]()
+    future.completeExceptionally(new NotImplementedError("method not implemented"))
+    future
   }
 
   override def buildTargetDependencySources(dependencySourcesParams: DependencySourcesParams): CompletableFuture[DependencySourcesResult] = {
-    // TODO
-    val result = new CompletableFuture[DependencySourcesResult]()
-    result.completeExceptionally(new NotImplementedError("method not implemented"))
-    result
+
+    io.println("**> buildTargetDependencySources")
+
+    val result = Try(new DependencySourcesResult(List.empty.asJava))
+
+    val future = new CompletableFuture[DependencySourcesResult]()
+    result match {
+      case Success(value) => future.complete(value)
+      case Failure(exception) => future.completeExceptionally(exception)
+    }
+    future
   }
 
   override def buildTargetResources(resourcesParams: ResourcesParams): CompletableFuture[ResourcesResult] = {
-    // TODO
-    val result = new CompletableFuture[ResourcesResult]()
-    result.completeExceptionally(new NotImplementedError("method not implemented"))
-    result
+    val future = new CompletableFuture[ResourcesResult]()
+    future.completeExceptionally(new NotImplementedError("method not implemented"))
+    future
   }
 
   override def buildTargetCompile(compileParams: CompileParams): CompletableFuture[bsp4j.CompileResult] = {
-    // TODO
-    val result = new CompletableFuture[bsp4j.CompileResult]()
-    result.completeExceptionally(new NotImplementedError("method not implemented"))
-    result
+    // TODO MVP
+    val future = new CompletableFuture[bsp4j.CompileResult]()
+    val result = new bsp4j.CompileResult(StatusCode.CANCELLED)
+    future.complete(result)
+    future
   }
 
   override def buildTargetTest(testParams: TestParams): CompletableFuture[TestResult] = {
-    val result = new CompletableFuture[TestResult]()
-    result.completeExceptionally(new NotImplementedError("method not implemented"))
-    result
+    val future = new CompletableFuture[TestResult]()
+    future.completeExceptionally(new NotImplementedError("method not implemented"))
+    future
   }
 
   override def buildTargetRun(runParams: RunParams): CompletableFuture[RunResult] = {
-    val result = new CompletableFuture[RunResult]()
-    result.completeExceptionally(new NotImplementedError("method not implemented"))
-    result
+    val future = new CompletableFuture[RunResult]()
+    future.completeExceptionally(new NotImplementedError("method not implemented"))
+    future
   }
 
   override def buildTargetCleanCache(cleanCacheParams: CleanCacheParams): CompletableFuture[CleanCacheResult] = {
-    // TODO
-    val result = new CompletableFuture[CleanCacheResult]()
-    result.completeExceptionally(new NotImplementedError("method not implemented"))
-    result
+    // TODO fury supports cleaning
+    val future = new CompletableFuture[CleanCacheResult]()
+    future.completeExceptionally(new NotImplementedError("method not implemented"))
+    future
   }
+
+
+  private def scalacOptionsItem(target: BuildTargetIdentifier, struct: Structure): Try[ScalacOptionsItem] = {
+    struct.moduleRef(target).map { ref =>
+      val art = struct.artifacts(ref)
+      val params = art.params.map(_.parameter)
+      val paths = art.binaries.map { p => p.javaPath.toUri.toString }
+      val classesDir = layout.classesDir.javaPath.toAbsolutePath.toUri.toString
+      new ScalacOptionsItem(target, params.asJava, paths.asJava, classesDir)
+    }
+  }
+
+
+  override def buildTargetScalacOptions(scalacOptionsParams: ScalacOptionsParams): CompletableFuture[ScalacOptionsResult] = {
+
+    io.println("**> buildTargetScalacOptions")
+
+    val result = for {
+      struct <- structure
+      targets = scalacOptionsParams.getTargets.asScala
+      items <- targets.traverse { target =>
+        struct.moduleRef(target).flatMap { ref =>
+          scalacOptionsItem(target, struct)
+        }
+      }
+    } yield new ScalacOptionsResult(items.asJava)
+
+    val future = new CompletableFuture[ScalacOptionsResult]()
+    result match {
+      case Success(value) => future.complete(value)
+      case Failure(exception) => future.completeExceptionally(exception)
+    }
+    future
+  }
+
+  override def buildTargetScalaTestClasses(scalaTestClassesParams: ScalaTestClassesParams): CompletableFuture[ScalaTestClassesResult] = {
+    val future = new CompletableFuture[ScalaTestClassesResult]()
+    val result = new ScalaTestClassesResult(List.empty.asJava)
+    future.complete(result)
+    future
+  }
+
+  override def buildTargetScalaMainClasses(scalaMainClassesParams: ScalaMainClassesParams): CompletableFuture[ScalaMainClassesResult] = {
+    val future = new CompletableFuture[ScalaMainClassesResult]()
+    val result = new ScalaMainClassesResult(List.empty.asJava)
+    future.complete(result)
+    future
+  }
+
 }
 
 object FuryBuildServer {
 
-  private def moduletoTarget(module: Module) = {
-    val id = moduleIdToBuildTargetIdentifier(module.id)
-    val tags = List(moduleKindToBuildTargetTag(module.kind))
+  class Cancelator {
+    var cancel: () => Unit = () => ()
+  }
+
+  case class Structure(modules: Map[ModuleRef, Module],
+                       graph: Map[ModuleRef, List[ModuleRef]],
+                       checkouts: Set[Checkout],
+                       artifacts: Map[ModuleRef, Artifact]) {
+
+    private[this] val
+    hashes: mutable.HashMap[ModuleRef, Digest] = new mutable.HashMap()
+
+    // TODO unify this with Compilation.hash
+    def hash(ref: ModuleRef): Digest = {
+      val artifact = artifacts(ref)
+      hashes.getOrElseUpdate(
+        ref, {
+          val food = (
+            artifact.kind,
+            artifact.main,
+            artifact.plugin,
+            artifact.checkouts,
+            artifact.binaries,
+            artifact.dependencies,
+            artifact.compiler.map { c => hash(c.ref) },
+            artifact.params,
+            artifact.intransitive,
+            artifact.sourcePaths,
+            graph(ref).map(hash)
+          )
+          food.digest[Md5]
+        }
+      )
+    }
+
+    def buildTarget(ref: ModuleRef): BuildTargetIdentifier = {
+      val uri = s"fury:${hash(ref).toString}"
+      new BuildTargetIdentifier(uri.toString)
+    }
+
+    def moduleRef(bti: BuildTargetIdentifier): Try[ModuleRef] = {
+      val id = new URI(bti.getUri).getSchemeSpecificPart
+      val bytes = java.util.Base64.getDecoder.decode(id) // TODO depends on assumption about how digest is encoded
+      val digest = Digest(Bytes(bytes))
+      modules
+        .find { case (ref, _) => hash(ref) == digest}
+        .map(_._1)
+        .ascribe(ItemNotFound(ModuleId(id)))
+    }
+  }
+
+  private def artifactToTarget(artifact: Artifact, struct: Structure) = {
+    val ref = artifact.ref
+    val id = struct.buildTarget(artifact.ref)
+    val tags = List(moduleKindToBuildTargetTag(artifact.kind))
     val languageIds = List("java", "scala") // TODO get these from somewhere?
-    val dependencies = module.compilerDependencies.map(d => moduleIdToBuildTargetIdentifier(d.moduleId))
+    val dependencies = artifact.dependencies.map(struct.buildTarget)
     val capabilities = new BuildTargetCapabilities(true, false, false)
 
-    val target = new BuildTarget(id, tags.asJava, languageIds.asJava, dependencies.toList.asJava, capabilities)
+    val target = new BuildTarget(id, tags.asJava, languageIds.asJava, dependencies.asJava, capabilities)
+    target.setDisplayName(moduleRefDisplayName(ref))
+
+    for {
+      compiler <- artifact.compiler
+      bs <- compiler.bloopSpec
+      if compiler.binaries.nonEmpty
+    } yield {
+      val libs = compiler.binaries.map(_.javaPath.toAbsolutePath.toUri.toString).asJava
+      val scalaBuildTarget = new ScalaBuildTarget(bs.org, bs.version, bs.version, ScalaPlatform.JVM, libs)
+      target.setDataKind(BuildTargetDataKind.SCALA)
+      target.setData(scalaBuildTarget)
+    }
+
     target
   }
 
-  private def moduleIdToBuildTargetIdentifier(moduleRef: ModuleId) =
-    new BuildTargetIdentifier(moduleRef.key)
+  private def moduleRefDisplayName(moduleRef: ModuleRef): String =
+    s"${moduleRef.projectId.key}/${moduleRef.moduleId.key}"
 
   private def moduleKindToBuildTargetTag(kind: Kind): String =
     kind match {
@@ -271,4 +421,12 @@ object FuryBuildServer {
       case Benchmarks => BuildTargetTag.BENCHMARK
       case Compiler | Plugin => BuildTargetTag.LIBRARY // mark these NO_IDE?
     }
+}
+
+case class BspTarget(id: BuildTargetIdentifier) extends Key(msg"BuildTargetIdentifier") {
+  override def key: String = id.getUri
+}
+
+object BspTarget {
+  implicit val msgShow: MsgShow[BspTarget] = v => UserMsg(_.url(v.key))
 }

--- a/src/core/bsp.scala
+++ b/src/core/bsp.scala
@@ -15,4 +15,260 @@
  */
 package fury
 
-object Bsp
+import java.io.{InputStream, OutputStream}
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, StandardOpenOption}
+import java.util.Collections
+import java.util.concurrent.{CompletableFuture, Future}
+
+import ch.epfl.scala.bsp4j
+import ch.epfl.scala.bsp4j._
+import org.eclipse.lsp4j.jsonrpc.Launcher
+
+import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
+
+
+object Bsp {
+
+  def createConfig(ctx: BspCli.Context): Try[ExitStatus] = {
+    val bspDir = ctx.layout.bspDir.extant()
+    val bspConfig = bspDir / "fury.json"
+    val write = for {
+      configFile <- ~Files.write(
+        bspConfig.javaPath,
+        bspConfigJson(ctx).serialize.getBytes(StandardCharsets.UTF_8),
+        StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING)
+    } yield {
+      println(s"BSP config written to $configFile")
+      Done
+    }
+
+    write.recover {
+      case err: Throwable =>
+        err.printStackTrace(System.err)
+        Abort
+    }
+  }
+
+  def bspConfigJson(ctx: BspCli.Context): Json = {
+    // FIXME we should use fury launch jar directly with java here
+    val furyExecutable = ctx.layout.home / "fury-0.4.0" / "bin" / "fury"
+
+    Json(
+      name = "Fury",
+      argv = List(
+        furyExecutable.javaPath.toAbsolutePath.toString,
+        "direct", "bsp", "run"
+      ),
+      version = "0.4.0-dev",
+      bspVersion = "2.0",
+      languages = List("java","scala")
+    )
+  }
+
+  def startServer(ctx: BspCli.Context): Try[ExitStatus] = {
+    val waiting = for {
+      running <- ~run(System.in, System.out, ctx.layout)
+    } yield {
+      System.err.println("started bsp process ...")
+      running.get()
+    }
+
+    waiting
+      .map { _ =>
+        System.err.println("completed bsp process")
+        Done
+      }
+      .recover {
+        case err: Throwable =>
+          System.err.println(s"bsp process encountered problem: ${err.getMessage}")
+          err.printStackTrace(System.err)
+          Abort
+      }
+  }
+
+
+  def run(in: InputStream, out: OutputStream, layout: Layout): Future[Void] = {
+
+    val server = new FuryBuildServer(layout)
+
+    val launcher = new Launcher.Builder[BuildClient]()
+      .setRemoteInterface(classOf[BuildClient])
+      .setLocalService(server)
+      .setInput(in)
+      .setOutput(out)
+      .create()
+
+    server.onConnectWithClient(launcher.getRemoteProxy)
+
+    launcher.startListening()
+  }
+
+}
+
+object BspCli {
+  case class Context(cli: Cli[CliParam[_]], layout: Layout)
+
+  def context(cli: Cli[CliParam[_]]): Try[Context] =
+    for {
+      layout <- cli.layout
+    } yield Context(cli, layout)
+}
+
+class FuryBuildServer(layout: Layout) extends BuildServer {
+  import FuryBuildServer._
+
+
+  override def buildInitialize(initializeBuildParams: InitializeBuildParams): CompletableFuture[InitializeBuildResult] = {
+
+    System.err.println("**> buildInitialize")
+
+    val capabilities = new BuildServerCapabilities()
+    capabilities.setBuildTargetChangedProvider(false)
+    val compileProvider = new CompileProvider(List("java","scala").asJava)
+    capabilities.setCompileProvider(compileProvider)
+    capabilities.setDependencySourcesProvider(false)
+    capabilities.setInverseSourcesProvider(false)
+    capabilities.setResourcesProvider(false)
+    val runProvider = new RunProvider(List.empty[String].asJava) // TODO fury can provide run
+    capabilities.setRunProvider(runProvider)
+    val testProvider = new TestProvider(List.empty[String].asJava) // fury does not yet have a dedicated test interface
+    capabilities.setTestProvider(testProvider)
+
+    val result = new InitializeBuildResult("Fury", "0.4.0-dev", "2.0.0", capabilities)
+    val future = new CompletableFuture[InitializeBuildResult]()
+    future.complete(result)
+    future
+  }
+
+  override def onBuildInitialized(): Unit = {
+    // TODO
+  }
+
+  override def onBuildExit(): Unit = {
+    // TODO
+  }
+
+  override def buildShutdown(): CompletableFuture[AnyRef] = {
+    System.err.println("**> buildShutdown")
+    // TODO
+    val result = new CompletableFuture[AnyRef]()
+    result.complete("shutdown elided") // FIXME ensure shutdown
+    result
+  }
+
+  override def workspaceBuildTargets(): CompletableFuture[WorkspaceBuildTargetsResult] = {
+
+    System.err.println("**> workspaceBuildTargets")
+
+    val config = Config()
+    val io = new Io(System.out, config)
+
+    val result = for {
+      layer <- Layer.read(io, layout.furyConfig, layout)
+      projects <- layer.projects
+    } yield {
+      // TODO respect current schema
+      val targets = projects
+        .flatMap(_.modules)
+        .map(moduletoTarget)
+        .toList
+
+      new WorkspaceBuildTargetsResult(targets.asJava)
+    }
+
+    val future = new CompletableFuture[WorkspaceBuildTargetsResult]()
+
+    result match {
+      case Success(value) => future.complete(value)
+      case Failure(exception) => future.completeExceptionally(exception)
+    }
+
+    future
+  }
+
+  override def buildTargetSources(sourcesParams: SourcesParams): CompletableFuture[SourcesResult] = {
+
+    System.err.println("**> buildTargetSources")
+
+    // TODO get sources for modules corresponding to targets
+    val res = new SourcesResult(Collections.emptyList())
+    val future = new CompletableFuture[SourcesResult]()
+    future.complete(res)
+    future
+  }
+
+  override def buildTargetInverseSources(inverseSourcesParams: InverseSourcesParams): CompletableFuture[InverseSourcesResult] = {
+    // TODO
+    val result = new CompletableFuture[InverseSourcesResult]()
+    result.completeExceptionally(new NotImplementedError("method not implemented"))
+    result
+  }
+
+  override def buildTargetDependencySources(dependencySourcesParams: DependencySourcesParams): CompletableFuture[DependencySourcesResult] = {
+    // TODO
+    val result = new CompletableFuture[DependencySourcesResult]()
+    result.completeExceptionally(new NotImplementedError("method not implemented"))
+    result
+  }
+
+  override def buildTargetResources(resourcesParams: ResourcesParams): CompletableFuture[ResourcesResult] = {
+    // TODO
+    val result = new CompletableFuture[ResourcesResult]()
+    result.completeExceptionally(new NotImplementedError("method not implemented"))
+    result
+  }
+
+  override def buildTargetCompile(compileParams: CompileParams): CompletableFuture[bsp4j.CompileResult] = {
+    // TODO
+    val result = new CompletableFuture[bsp4j.CompileResult]()
+    result.completeExceptionally(new NotImplementedError("method not implemented"))
+    result
+  }
+
+  override def buildTargetTest(testParams: TestParams): CompletableFuture[TestResult] = {
+    val result = new CompletableFuture[TestResult]()
+    result.completeExceptionally(new NotImplementedError("method not implemented"))
+    result
+  }
+
+  override def buildTargetRun(runParams: RunParams): CompletableFuture[RunResult] = {
+    val result = new CompletableFuture[RunResult]()
+    result.completeExceptionally(new NotImplementedError("method not implemented"))
+    result
+  }
+
+  override def buildTargetCleanCache(cleanCacheParams: CleanCacheParams): CompletableFuture[CleanCacheResult] = {
+    // TODO
+    val result = new CompletableFuture[CleanCacheResult]()
+    result.completeExceptionally(new NotImplementedError("method not implemented"))
+    result
+  }
+}
+
+object FuryBuildServer {
+
+  private def moduletoTarget(module: Module) = {
+    val id = moduleIdToBuildTargetIdentifier(module.id)
+    val tags = List(moduleKindToBuildTargetTag(module.kind))
+    val languageIds = List("java", "scala") // TODO get these from somewhere?
+    val dependencies = module.compilerDependencies.map(d => moduleIdToBuildTargetIdentifier(d.moduleId))
+    val capabilities = new BuildTargetCapabilities(true, false, false)
+
+    val target = new BuildTarget(id, tags.asJava, languageIds.asJava, dependencies.toList.asJava, capabilities)
+    target
+  }
+
+  private def moduleIdToBuildTargetIdentifier(moduleRef: ModuleId) =
+    new BuildTargetIdentifier(moduleRef.key)
+
+  private def moduleKindToBuildTargetTag(kind: Kind): String =
+    kind match {
+      case Library => BuildTargetTag.LIBRARY
+      case Application => BuildTargetTag.APPLICATION
+      case Benchmarks => BuildTargetTag.BENCHMARK
+      case Compiler | Plugin => BuildTargetTag.LIBRARY // mark these NO_IDE?
+    }
+}

--- a/src/core/config.scala
+++ b/src/core/config.scala
@@ -15,7 +15,6 @@
  */
 package fury
 
-import exoskeleton._
 import guillotine._
 
 import scala.util._

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -107,7 +107,7 @@ object Binary {
 case class Binary(binRepo: BinRepoId, group: String, artifact: String, version: String) {
   def spec = str"$group:$artifact:$version"
 
-  def paths(io: Io, shell: Shell): Future[List[Path]] = Coursier.fetch(io, this)
+  def paths(io: Io): Future[List[Path]] = Coursier.fetch(io, this)
 }
 
 case class Module(
@@ -530,7 +530,7 @@ case class Universe(entities: Map[ProjectId, Entity] = Map()) {
       compiler <- if (module.compiler == ModuleRef.JavaRef) Success(None)
                  else artifact(io, module.compiler, layout).map(Some(_))
       binaries <- ~Await.result(
-                     module.allBinaries.map(_.paths(io, layout.shell)).sequence.map(_.flatten),
+                     module.allBinaries.map(_.paths(io)).sequence.map(_.flatten),
                      duration.Duration.Inf)
       checkouts <- checkout(ref, layout)
     } yield
@@ -574,7 +574,7 @@ case class Universe(entities: Map[ProjectId, Entity] = Map()) {
   def ++(that: Universe): Universe =
     Universe(entities ++ that.entities)
 
-  private[this] def dependencies(io: Io, ref: ModuleRef, layout: Layout): Try[Set[ModuleRef]] =
+  private[fury] def dependencies(io: Io, ref: ModuleRef, layout: Layout): Try[Set[ModuleRef]] =
     for {
       entity <- entity(ref.projectId)
       module <- entity.project(ref.moduleId)

--- a/src/core/layout.scala
+++ b/src/core/layout.scala
@@ -53,6 +53,7 @@ case class Layout(home: Path, pwd: Path, env: Environment, base: Path) {
   private[this] val userDir          = (home / ".furyrc").extant()
 
   lazy val furyDir: Path       = (base / ".fury").extant()
+  lazy val bspDir: Path        = (base / ".bsp").extant()
   lazy val historyDir: Path    = (furyDir / "history").extant()
   lazy val bloopDir: Path      = (furyDir / "bloop").extant()
   lazy val classesDir: Path    = (furyDir / "classes").extant()

--- a/src/core/package.scala
+++ b/src/core/package.scala
@@ -21,9 +21,7 @@ import gastronomy._
 
 import scala.collection.immutable.SortedSet
 import scala.language.implicitConversions
-
 import scala.util._
-import java.io._
 
 object `package` {
   implicit def resolverExt[T](items: Traversable[T]): ResolverExt[T] = new ResolverExt[T](items)

--- a/src/menu/menu.scala
+++ b/src/menu/menu.scala
@@ -20,12 +20,16 @@ import scala.util._
 object FuryMenu {
 
   def menu(aliases: List[Action[Cli[CliParam[_]]]]): Menu[Cli[CliParam[_]], _] =
-    Menu('main, "main menu", (x: Cli[CliParam[_]]) => Success(x), 'build)((List(
+    Menu('main, "main menu", (x: Cli[CliParam[_]]) => Success(x), 'build)(List(
         Action('about, msg"about Fury", BuildCli.about),
         Menu('alias, msg"view and edit command aliases", AliasCli.context, 'list)(
             Action('add, msg"add a command alias to the layer", AliasCli.add),
             Action('remove, msg"remove a command alias from the layer", AliasCli.remove),
             Action('list, msg"list command aliases", AliasCli.list)
+        ),
+        Menu('bsp, msg"Build Server Protocol support", BspCli.context, 'run)(
+            Action('init, msg"create bsp configuration", Bsp.createConfig),
+            Action('run, msg"start bsp server", Bsp.startServer)
         ),
         Menu('binary, msg"manage binary dependencies for the module", BinaryCli.context, 'list)(
             Action('add, msg"add a binary dependency to the module", BinaryCli.add),
@@ -114,7 +118,7 @@ object FuryMenu {
             Action('init, msg"initialize a new Fury layer", LayerCli.init),
             Action('projects, msg"show all available projects", LayerCli.projects)
         )
-    ) ::: aliases): _*)
+    ) ::: aliases: _*)
 
   def help(cli: Cli[CliParam[_]]): Try[ExitStatus] =
     for {


### PR DESCRIPTION
Current status: very basic bsp server support. Works well enough to import fury itself into IntelliJ latest Nightlies (protocol version 2.0.0-M4, partially incompatible with 2.0.0-M3). Compiling is not yet supported.

Adds 2 commands:
* `fury bsp init` - writes a bsp connection file to the current workspace
* ` fury bsp run` - starts a bsp server

Starting the bsp server via menu command didn't work in conjuction with IntelliJ, probably due to Nailgun, so the connection file for now defines a command to start a Fury JVM process directly.

The server is currently stateless, so it may recompute fury structure on every request, which may or may not have performance implications for larger projects.

Schemas aren't respected, it just uses the mainSchema

Overall this is pretty basic and kind of dirty and some code is duplicated so as not to mess to much with the rest of Fury, but I'd appreciate general feedback how to make it fit in better.