### PR TITLE
Shuffled `fury bsp` command a little

### DIFF
--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -372,7 +372,8 @@ object LayerCli {
       layer  <- ~Layer()
       _      <- layout.furyConfig.mkParents()
       _      <- ~Layer.save(io, layer, layout)
-      _      <- ~io.println("Created empty layer.fury")
+      _      <- Bsp.createConfig(layout)
+      _      <- ~io.println("Created empty layer.fury and BSP configuration")
     } yield io.await()
 
   def projects(cli: Cli[CliParam[_]]): Try[ExitStatus] =

--- a/src/menu/menu.scala
+++ b/src/menu/menu.scala
@@ -29,10 +29,7 @@ object FuryMenu {
             Action('remove, msg"remove a command alias from the layer", AliasCli.remove),
             Action('list, msg"list command aliases", AliasCli.list)
         ),
-        Menu('bsp, msg"Build Server Protocol support", BspCli.context, 'run)(
-            Action('init, msg"create bsp configuration", Bsp.createConfig),
-            Action('run, msg"start bsp server", Bsp.startServer)
-        ),
+        Action('bsp, msg"start BSP server", Bsp.startServer, false),
         Menu('binary, msg"manage binary dependencies for the module", BinaryCli.context, 'list)(
             Action('add, msg"add a binary dependency to the module", BinaryCli.add),
             Action('remove, msg"remove a binary dependency from the module", BinaryCli.remove),


### PR DESCRIPTION
This makes a couple of changes:
 - changes the BSP server command to `fury bsp`
 - hides the command in tab-completion
 - creates the `.bsp/fury.json` file when initializing the repository, notwithstanding the limitations mentioned by @jastice.