### PR TITLE
Use msg interpolator to save some characters, "fix" core-test compilation

### DIFF
--- a/src/core-test/fury/Tests.scala
+++ b/src/core-test/fury/Tests.scala
@@ -5,7 +5,8 @@ import probably.TestApp
 object Tests {
   private val testSuites = List[TestApp](
       DirectedGraphTest,
-      LayerRepositoryTest
+      LayerRepositoryTest,
+      TablesTest
   )
 
   def main(args: Array[String]): Unit = testSuites.foreach(_.main(args))

--- a/src/core-test/fury/directedgraph/DirectedGraphTest.scala
+++ b/src/core-test/fury/directedgraph/DirectedGraphTest.scala
@@ -19,6 +19,7 @@ import java.nio.ByteBuffer
 import java.nio.ByteBuffer.wrap
 
 import probably._
+import fury.core._
 
 import scala.language.implicitConversions
 

--- a/src/core-test/fury/layer/LayerRepositoryTest.scala
+++ b/src/core-test/fury/layer/LayerRepositoryTest.scala
@@ -1,6 +1,8 @@
 package fury
 import java.nio.file.Files
+import java.nio.file.Path
 
+import fury.core._
 import probably._
 
 /**

--- a/src/core-test/fury/tables/TablesTest.scala
+++ b/src/core-test/fury/tables/TablesTest.scala
@@ -1,0 +1,25 @@
+package fury
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+import fury.core._
+import fury.strings._
+
+import probably._
+
+object TablesTest extends TestApp {
+  override def tests(): Unit = {
+    test("contextString with showSchema=true") {
+      Tables(Config())
+    }.assert { tables =>
+      tables.contextString(msg"foo", true, msg"bar", msg"baz").string(Theme.NoColor) == "foo/bar/baz"
+    }
+
+    test("contextString with showSchema=false") {
+      Tables(Config())
+    }.assert { tables =>
+      tables.contextString(msg"foo", false, msg"bar", msg"baz").string(Theme.NoColor) == "foo/baz"
+    }
+  }
+}

--- a/src/core-test/fury/tables/TablesTest.scala
+++ b/src/core-test/fury/tables/TablesTest.scala
@@ -11,15 +11,19 @@ import probably._
 object TablesTest extends TestApp {
   override def tests(): Unit = {
     test("contextString with showSchema=true") {
-      Tables(Config())
-    }.assert { tables =>
-      tables.contextString(msg"foo", true, msg"bar", msg"baz").string(Theme.NoColor) == "foo/bar/baz"
+      val tables = Tables(Config())
+
+      tables.contextString(msg"foo", true, msg"bar", msg"baz").string(Theme.NoColor)
+    }.assert {
+      _ == "foo/bar/baz"
     }
 
     test("contextString with showSchema=false") {
-      Tables(Config())
-    }.assert { tables =>
-      tables.contextString(msg"foo", false, msg"bar", msg"baz").string(Theme.NoColor) == "foo/baz"
+      val tables = Tables(Config())
+
+      tables.contextString(msg"foo", false, msg"bar", msg"baz").string(Theme.NoColor)
+    }.assert {
+      _ == "foo/baz"
     }
   }
 }

--- a/src/core/tables.scala
+++ b/src/core/tables.scala
@@ -51,14 +51,14 @@ case class Tables(config: Config) {
     case s          => Ansi.green("-" + s)
   }.join("\n")
 
-  implicit private def option[T: AnsiShow]: AnsiShow[Option[T]] = _ match {
+  implicit private def option[T: AnsiShow]: AnsiShow[Option[T]] = {
     case None    => "-"
     case Some(v) => implicitly[AnsiShow[T]].show(v)
   }
 
   private def refinedModuleDep(projectId: ProjectId): AnsiShow[SortedSet[ModuleRef]] =
     _.map {
-      case ref @ ModuleRef(p, m, intransitive, _) =>
+      case ModuleRef(p, m, intransitive, _) =>
         val extra = (if (intransitive) msg"*" else msg"")
         if (p == projectId) msg"${theme.module(m.key)}$extra"
         else msg"${theme.project(p.key)}${theme.gray("/")}${theme.module(m.key)}$extra"

--- a/src/core/tables.scala
+++ b/src/core/tables.scala
@@ -40,9 +40,7 @@ case class Tables(config: Config) {
 
   def contextString(layer: UserMsg, showSchema: Boolean, elements: UserMsg*): UserMsg =
     (if (showSchema) elements else elements.tail).foldLeft(layer) { (l, r) =>
-      UserMsg { theme =>
-        s"${l.string(theme)}/${r.string(theme)}"
-      }
+      msg"$l/$r"
     }
 
   implicit private val parameter: AnsiShow[SortedSet[Parameter]] = _.map(_.name).map {


### PR DESCRIPTION
Just a simple change to start getting familiar with the codebase.

Also: "fixing" tests by adding imports (I'm pretty suspicious about this, as the tests being broken would mean they are not being run on CI or the compilation errors are ignored - if there are some global imports configured, let me know how to run the tests with them).