### PR TITLE
change the error format slightly

### DIFF
--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -278,7 +278,7 @@ class BuildingClient() extends BuildClient {
       multiplexer(modref) = DiagnosticMsg(
           modref,
           CompilerDiagnostic(
-              msg"""$severity ${modref}${'>'}${repo}${':'}${filePath}${'@'}${lineNo}${':'}
+              msg"""$severity ${modref}${'>'}${repo}${':'}${filePath} ${'+'}${lineNo}${':'}
   ${'|'} ${UserMsg(
                   theme =>
                     diag.getMessage


### PR DESCRIPTION
You can now copy/paste filenames into a vim command line