### PR TITLE
Allowed application modules to connect to any servers on the network.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ steps:
 
 - name: 'gcr.io/cloud-builders/docker'
   args: ['run', '-u', 'bash_user', '-w', '/home/bash_user', '-t', 'fury/ci', '/integration']
-  timeout: 240s
+  timeout: 360s
   id: 'integration'
 
 - name: 'gcr.io/cloud-builders/docker'

--- a/etc/security/fury_application_module.policy
+++ b/etc/security/fury_application_module.policy
@@ -3,4 +3,5 @@ grant {
       permission java.lang.RuntimePermission "getenv.SHARED", "read";
       permission java.util.PropertyPermission "fury.sharedDir", "read";
       permission java.util.PropertyPermission "scala.*", "read";
+      permission java.net.SocketPermission "*", "connect,resolve";
 };

--- a/test/policy_network_test/run.sh
+++ b/test/policy_network_test/run.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+set -x
+
+source $TESTROOTDIR/tests_lib
+
+fury layer init
+fury project add -n policy-network-test
+fury repo add -u https://github.com/propensive/base.git -n base
+fury import add -i base:2.12.6
+
+# Try sending a request to an external server
+fury module add -n hello-internet
+fury source add -d src
+fury module update -c scala/compiler
+fury module update --type application
+fury module update --main test.HelloInternet
+fury

--- a/test/policy_network_test/src/main.scala
+++ b/test/policy_network_test/src/main.scala
@@ -1,0 +1,11 @@
+package test
+
+object HelloInternet {
+
+  def main(args: Array[String]) = {
+    val url = "https://fury.build"
+    val result = scala.io.Source.fromURL(url).mkString
+    Predef.assert(result.take(15) == "<!DOCTYPE html>")
+  }
+
+}


### PR DESCRIPTION
If we are going to use application modules for tests, we have to allow these modules to communicate over the network.

See https://docs.oracle.com/javase/8/docs/technotes/guides/security/permissions.html#SocketPermission.