### PR TITLE
Replaces the menu placeholder for `fury kill` with a more appropriate one.

### DIFF
--- a/src/menu/menu.scala
+++ b/src/menu/menu.scala
@@ -91,7 +91,7 @@ object FuryMenu {
             Action('list, msg"list sources for the module", SourceCli.list)
         ),
         Action('stop, msg"gracefully shut down the Fury server", Main.shutdown()),
-        Action('kill, msg"kill the Fury server", BuildCli.about),
+        Action('kill, msg"kill the Fury server", BuildCli.notImplemented),
         Menu('schema, msg"manage the current schema", SchemaCli.context, 'list)(
             Action('add, msg"add a schema to the layer", SchemaCli.add),
             Action('remove, msg"remove a schema from the layer", SchemaCli.remove),


### PR DESCRIPTION
This chance doesn't affect the program's behavior, because the `kill` command is [handled](https://github.com/propensive/fury/blob/master/etc/fury#L31) in the starter script and doesn't even invoke `fury.Main`.