### PR TITLE
Fixed the error message for the case when the project could not be found

### DIFF
--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -318,8 +318,8 @@ object BuildCli {
                   }
       invoc       <- cli.read()
       io          <- invoc.io()
-      module      <- optModule.ascribe(UnspecifiedModule())
       project     <- optProject.ascribe(UnspecifiedProject())
+      module      <- optModule.ascribe(UnspecifiedModule())
       hierarchy   <- schema.hierarchy(io, layout.base, layout)
       universe    <- hierarchy.universe
       compilation <- universe.compilation(io, module.ref(project), layout)
@@ -344,8 +344,8 @@ object BuildCli {
       optModule <- ~optModuleId.flatMap { arg =>
                     optProject.flatMap(_.modules.findBy(arg).toOption)
                   }
-      module      <- optModule.ascribe(UnspecifiedModule())
       project     <- optProject.ascribe(UnspecifiedProject())
+      module      <- optModule.ascribe(UnspecifiedModule())
       hierarchy   <- schema.hierarchy(io, layout.base, layout)
       universe    <- hierarchy.universe
       artifact    <- universe.artifact(io, module.ref(project), layout)

--- a/src/core/package.scala
+++ b/src/core/package.scala
@@ -18,7 +18,6 @@ package fury.core
 import fury.strings._, fury.io._
 
 import escritoire._
-import eucalyptus._
 import gastronomy._
 
 import scala.collection.immutable.SortedSet

--- a/src/module/module.scala
+++ b/src/module/module.scala
@@ -309,8 +309,8 @@ object BinaryCli {
       invoc       <- cli.read()
       io          <- invoc.io()
       binaryArg   <- invoc(BinaryArg)
-      module      <- optModule.ascribe(UnspecifiedModule())
       project     <- optProject.ascribe(UnspecifiedProject())
+      module      <- optModule.ascribe(UnspecifiedModule())
       binaryToDel <- ~module.binaries.find(_.spec == binaryArg)
       force       <- ~invoc(ForceArg).isSuccess
       layer <- Lenses.updateSchemas(optSchemaId, layer, force)(
@@ -326,8 +326,8 @@ object BinaryCli {
       cli       <- cli.hint(BinaryRepoArg, List(RepoId("central")))
       invoc     <- cli.read()
       io        <- invoc.io()
-      module    <- optModule.ascribe(UnspecifiedModule())
       project   <- optProject.ascribe(UnspecifiedProject())
+      module    <- optModule.ascribe(UnspecifiedModule())
       binaryArg <- invoc(BinaryArg)
       repoId    <- ~invoc(BinaryRepoArg).toOption.getOrElse(BinRepoId.Central)
       binary    <- Binary.unapply(repoId, binaryArg)
@@ -384,8 +384,8 @@ object ParamCli {
       invoc    <- cli.read()
       io       <- invoc.io()
       paramArg <- invoc(ParamArg)
-      module   <- optModule.ascribe(UnspecifiedModule())
       project  <- optProject.ascribe(UnspecifiedProject())
+      module   <- optModule.ascribe(UnspecifiedModule())
       force    <- ~invoc(ForceArg).isSuccess
       layer <- Lenses.updateSchemas(optSchemaId, layer, force)(
                   Lenses.layer.params(_, project.id, module.id))(_(_) -= paramArg)
@@ -399,8 +399,8 @@ object ParamCli {
       cli     <- cli.hint(ParamArg)
       invoc   <- cli.read()
       io      <- invoc.io()
-      module  <- optModule.ascribe(UnspecifiedModule())
       project <- optProject.ascribe(UnspecifiedProject())
+      module  <- optModule.ascribe(UnspecifiedModule())
       param   <- invoc(ParamArg)
       layer <- Lenses.updateSchemas(optSchemaId, layer, true)(
                   Lenses.layer.params(_, project.id, module.id))(_(_) += param)

--- a/src/source/source.scala
+++ b/src/source/source.scala
@@ -70,8 +70,8 @@ object SourceCli {
       invoc   <- cli.read()
       io      <- invoc.io()
       raw     <- ~invoc(RawArg).isSuccess
-      module  <- optModule.ascribe(UnspecifiedModule())
       project <- optProject.ascribe(UnspecifiedProject())
+      module  <- optModule.ascribe(UnspecifiedModule())
       rows    <- ~module.sources.to[List]
       table   <- ~Tables(config).show(Tables(config).sources, cli.cols, rows, raw)(_.repoIdentifier)
       schema  <- defaultSchema
@@ -92,8 +92,8 @@ object SourceCli {
       io          <- invoc.io()
       sourceArg   <- invoc(SourceArg)
       source      <- ~Source.unapply(sourceArg)
-      module      <- optModule.ascribe(UnspecifiedModule())
       project     <- optProject.ascribe(UnspecifiedProject())
+      module      <- optModule.ascribe(UnspecifiedModule())
       sourceToDel <- ~module.sources.find(Some(_) == source)
       force       <- ~invoc(ForceArg).isSuccess
       layer <- Lenses.updateSchemas(optSchemaId, layer, force)(
@@ -124,8 +124,8 @@ object SourceCli {
       cli       <- cli.hint(SourceArg, extSrcs ++ localSrcs ++ sharedSrcs)
       invoc     <- cli.read()
       io        <- invoc.io()
-      module    <- optModule.ascribe(UnspecifiedModule())
       project   <- optProject.ascribe(UnspecifiedProject())
+      module    <- optModule.ascribe(UnspecifiedModule())
       sourceArg <- invoc(SourceArg)
       source    <- ~Source.unapply(sourceArg)
       layer <- Lenses.updateSchemas(optSchemaId, layer, true)(


### PR DESCRIPTION
Sometimes the module reference given by the user is good, but the project reference is bad (e. g. due to a typo). I believe that in cases when neither project nor module can be resolved, the project error is a more important one, and its message should be displayed.