### PR TITLE
Better connection management

### DIFF
--- a/src/core/coursier.scala
+++ b/src/core/coursier.scala
@@ -20,7 +20,7 @@ import fury.io._, fury.strings._
 import scala.util._
 import scala.collection._
 import scala.concurrent._
-import coursier.{Module => CModule,  _}
+import coursier.{Module => CModule, _}
 
 object Coursier {
 
@@ -30,7 +30,7 @@ object Coursier {
     mutable.HashMap()
 
   def fetch(io: Io, binary: Binary): Future[List[Path]] = {
-    def resolveRepository(repoId: String): Future[Repository] = {
+    def resolveRepository(repoId: String): Future[Repository] =
       coursier.cache.CacheParse
         .repositories(Seq(repoId))
         .either
@@ -42,7 +42,6 @@ object Coursier {
           Future.failed[Repository](UnknownBinaryRepository(binary.binRepo))
         }
         .merge
-    }
 
     def resolve(repo: Repository): Future[List[Path]] = {
       io.println(msg"Resolving $binary")
@@ -50,9 +49,9 @@ object Coursier {
         .Fetch()
         .addRepositories(repo)
         .addDependencies(
-          Dependency(
-            CModule(Organization(binary.group), ModuleName(binary.artifact)),
-            binary.version))
+            Dependency(
+                CModule(Organization(binary.group), ModuleName(binary.artifact)),
+                binary.version))
         .future
         .map(_._2.to[List].map { a =>
           Path(a._2.getAbsolutePath)

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -199,7 +199,7 @@ object Compilation {
 
   private val compilationThreadPool = Executors.newCachedThreadPool()
 
-  val bspPool: Pool[Path, BspConnection] = new Pool[Path, BspConnection](3, 3000L) {
+  val bspPool: Pool[Path, BspConnection] = new Pool[Path, BspConnection](5000L) {
 
     def destroy(value: BspConnection): Unit = value.shutdown()
 

--- a/src/module/module.scala
+++ b/src/module/module.scala
@@ -166,7 +166,7 @@ object ModuleCli {
   def remove(ctx: Context): Try[ExitStatus] = {
     import ctx._
     for {
-      cli    <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
+      cli <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
       cli <- cli.hint(
                 CompilerArg,
                 defaultSchema.toOption.to[List].flatMap(_.compilerRefs(Io.silent(config), layout)))

--- a/src/ogdl-test/fury/Tests.scala
+++ b/src/ogdl-test/fury/Tests.scala
@@ -5,8 +5,8 @@ import probably.TestApp
 
 object Tests {
   private val testSuites = List[TestApp](
-    OgdlParserTest,
-    OgdlSerializerTest
+      OgdlParserTest,
+      OgdlSerializerTest
   )
 
   def main(args: Array[String]): Unit = testSuites.foreach(_.execute())

--- a/src/ogdl-test/fury/ogdl/OgdlSerializerTest.scala
+++ b/src/ogdl-test/fury/ogdl/OgdlSerializerTest.scala
@@ -55,11 +55,12 @@ object OgdlSerializerTest extends TestApp {
     }.assert(_ == "AB\n")
 
     test("Sibling nodes have the same indentation level") {
-      write(graph(
-        "A" ->
-          graph("B" -> graph("C", "D")),
-        "E"
-      ))
+      write(
+          graph(
+              "A" ->
+                graph("B" -> graph("C", "D")),
+              "E"
+          ))
     }.assert(_ == "A\tB\tCD\nE\n")
   }
 


### PR DESCRIPTION
This might help improve the concurrency issues with running Fury on many different projects. We now use an explicit thread pool for launcher connections, and explicitly cancel launcher futures when they're shutdown.