### PR TITLE
Added an option to kill Fury and Bloop processes for sure.

### DIFF
--- a/etc/fury
+++ b/etc/fury
@@ -41,7 +41,22 @@ coursier(){
 }
 
 killFury() {
-  nailgun ng-stop > /dev/null && printf 'Fury daemon has shut down\n'
+  case "$1" in
+    "--force")
+      nuke &
+      ;;
+    *)
+      nailgun ng-stop > /dev/null && printf 'Fury daemon has shut down\n'
+      ;;
+  esac
+}
+
+nuke(){
+bash <<END
+  printf 'Killing everything that looks like fury or bloop...\n'
+  pkill --signal SIGKILL -f '(fury)|(bloop)'
+  pgrep -f '(fury)|(bloop)' && printf 'Processes with these PIDs have survived...\n' || printf 'Done! \n'
+END
 }
 
 stopFury() {
@@ -98,7 +113,7 @@ case "$1" in
     silently startFuryDirect "${@:2}"
     ;;
   "kill")
-    silently killFury
+    silently killFury "${@:2}"
     ;;
   "stop")
     silently stopFury


### PR DESCRIPTION
Fury tends to leave a lot of processes lingering in the background even after it is stopped, and these processes don't respect SIGTERM. Perhaps this is related to Fury being recompiled and restarted, but I'm not sure. Regardless, I think that an easy and sure way to nuke these processes will save quite some hassle during development.