### PR TITLE
Implemented saving BSP traces for failed compilation tasks.

### DIFF
--- a/src/core/layout.scala
+++ b/src/core/layout.scala
@@ -68,6 +68,7 @@ case class Layout(home: Path, pwd: Path, env: Environment, base: Path) {
   lazy val workDir: Path       = (furyDir / "work").extant()
   lazy val sharedDir: Path     = (furyDir / "build" / uniqueId).extant()
   lazy val errorLogfile: Path  = logsDir.extant() / s"$nowString-$uniqueId.log"
+  lazy val traceLogfile: Path  = logsDir.extant() / s"$nowString-$uniqueId.bsp-trace.log"
   lazy val userConfig: Path    = userDir / "config.fury"
   lazy val aliasesPath: Path   = userDir / "aliases"
 


### PR DESCRIPTION
The complete trace of BSP communication is useful for debugging errors that otherwise are just [swallowed](https://github.com/propensive/fury/blob/master/src/core/data.scala#L245). 

In particular, this should help identify the issue that makes [scala-logging](https://github.com/lightbend/scala-logging) incompatible with Fury.