### PR TITLE
Do not force recreation of directories (and all subtasks)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ dist/bundle/lib/%.jar: bootstrap/bin bootstrap/bin/fury/.version dist/bundle/lib
 
 %/.dir:
 	mkdir -p ${@D}
+	touch ${@D}/.dir
 
 dist/bundle/bin/fury: $(foreach D, $(BINDEPS), dist/bundle/bin/$(D))
 	cp etc/fury $@


### PR DESCRIPTION
Touching `.dir` means that subtasks which depend on `somedir/.dir` won't get
invalidated and re-run every time.