### PR TITLE
Fixed the error message for conflicting projects.

### DIFF
--- a/src/core/exception.scala
+++ b/src/core/exception.scala
@@ -33,7 +33,7 @@ case class UnspecifiedMain(module: ModuleId)          extends FuryException
 case class GraalVMError(message: String)              extends FuryException
 case class InvalidKind(expected: Kind)                extends FuryException
 case class UnspecifiedRepo()                          extends FuryException
-case class ProjectConflict(ids: Set[ProjectId])       extends FuryException
+case class ProjectConflict(ids: Set[ProjectId], h1: Hierarchy, h2: Hierarchy)       extends FuryException
 case class SchemaDifferences()                        extends FuryException
 case class LauncherFailure(msg: String)               extends FuryException
 

--- a/src/menu/recovery.scala
+++ b/src/menu/recovery.scala
@@ -31,10 +31,12 @@ object Recovery {
       err match {
         case EarlyCompletions() =>
           Done
-        case ProjectConflict(ps) =>
-          cli.abort(
-              msg"""Your dependency tree contains references to two or more conflicting projects: ${ps
-                .mkString(", ")}""")
+        case ProjectConflict(ps, h1, h2) =>
+          val projectIds = ps.toSeq.sortBy(_.key).map { x => msg"$x" }
+          val message = msg"Your dependency tree contains references to two or more conflicting projects: "
+          val beginning = projectIds.tail.foldLeft(message + projectIds.head)(_ + ", " + _)
+          val ending = msg". The conflicting hierarchies are located at ${h1.dir} and ${h2.dir}"
+          cli.abort(beginning + ending)
         case e: SchemaDifferences =>
           cli.abort(
               msg"""You are attempting to make this change to all schemas, however the value you are


### PR DESCRIPTION
This message used to say something like "Your dependency tree contains references to two or more conflicting projects: ProjectId(magnolia), ProjectId(contextual)", which doesn't give the slightest hint about which schemas actually cause the conflict. 