### PR TITLE
Fixed the connection pool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION=${shell sh -c 'cat .version 2> /dev/null || git --git-dir git/fury/.git describe --exact-match --tags 2> /dev/null || git --git-dir git/fury/.git rev-parse --short HEAD'}
 MKFILE := $(abspath $(lastword $(MAKEFILE_LIST)))
 ROOTDIR := $(dir $(MKFILE))
-BLOOPVERSION=1.3.0-RC1
+BLOOPVERSION=1.3.2
 DEPS=kaleidoscope optometry eucalyptus exoskeleton escritoire mercator magnolia gastronomy contextual guillotine
 REPOS:=$(foreach dep, $(DEPS), bootstrap/git/$(dep))
 BINDEPS=launcher ng.py ng

--- a/etc/install.sh
+++ b/etc/install.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-BLOOP_VERSION="1.2.5"
 DESTINATION="$HOME/fury-$FURY_VERSION"
 CONFIG="$HOME/.furyrc"
 

--- a/layer.fury
+++ b/layer.fury
@@ -66,10 +66,10 @@ schemas	default	id	default
 								hidden	false
 						params	
 						sources	src/core	src/core
-						binaries	ch.epfl.scala:bloop-launcher_2.12:1.3.0-RC1	binRepo	bintray:scalacenter/releases
+						binaries	ch.epfl.scala:bloop-launcher_2.12:1.3.2	binRepo	bintray:scalacenter/releases
 								group	ch.epfl.scala
 								artifact	bloop-launcher_2.12
-								version	1.3.0-RC1
+								version	1.3.2
 							ch.epfl.scala:bsp4j:2.0.0-M4	binRepo	central
 								group	ch.epfl.scala
 								artifact	bsp4j

--- a/src/core-test/PoolTest.scala
+++ b/src/core-test/PoolTest.scala
@@ -1,0 +1,36 @@
+package fury
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import fury.core.Pool
+import probably._
+
+object PoolTest extends TestApp {
+  
+  private val dummyPool: Pool[String, Symbol] = new Pool[String, Symbol](10L) {
+    override def create(key: String): Symbol = Symbol(key)
+    override def destroy(value: Symbol): Unit = ()
+  }
+
+  override def tests(): Unit = {
+    test("reuse existing entries") {
+      dummyPool.borrow("a/b/c"){void}
+      dummyPool.borrow("a/b/x"){void}
+      dummyPool.borrow("a/b/c"){void}
+      dummyPool.size
+    }.assert(_ == 2)
+
+    test("Return correct values") {
+      var result1: Symbol = null
+      var result2: Symbol = null
+      var result3: Symbol = null
+      dummyPool.borrow("a/b/c"){result1 = _}
+      dummyPool.borrow("a/b/x"){result2 = _}
+      dummyPool.borrow("a/b/c"){result3 = _}
+      (result1, result2, result3)
+    }.assert(_ == (Symbol("a/b/c"), Symbol("a/b/x"), Symbol("a/b/c")))
+  }
+  
+  private def void: Any => Unit = _ => ()
+
+}

--- a/src/core-test/PoolTest.scala
+++ b/src/core-test/PoolTest.scala
@@ -10,6 +10,7 @@ object PoolTest extends TestApp {
   private val dummyPool: Pool[String, Symbol] = new Pool[String, Symbol](10L) {
     override def create(key: String): Symbol = Symbol(key)
     override def destroy(value: Symbol): Unit = ()
+    override def isBad(value: Symbol): Boolean = false
   }
 
   override def tests(): Unit = {

--- a/src/core-test/Tests.scala
+++ b/src/core-test/Tests.scala
@@ -6,7 +6,8 @@ object Tests {
   private val testSuites = List[TestApp](
       DirectedGraphTest,
       LayerRepositoryTest,
-      TablesTest
+      TablesTest,    
+      PoolTest
   )
 
   def main(args: Array[String]): Unit = testSuites.foreach(_.execute())

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -262,7 +262,7 @@ object BspConnectionManager {
       System.out.println(s"Launcher status: $status")
       status match {
         case SuccessfulRun => ()
-        case _ => handle.close()
+        case x => throw new Exception(s"Launcher failed: $x")
       }
     }
 
@@ -278,6 +278,10 @@ object Compilation {
   val bspPool: Pool[Path, BspConnection] = new Pool[Path, BspConnection](60000L) {
 
     def destroy(value: BspConnection): Unit = value.shutdown()
+
+    def isBad(value: BspConnection): Boolean = {
+      value.future.isDone
+    }
 
     def create(dir: Path): BspConnection = {
       val bspMessageBuffer = new CharArrayWriter()

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -210,14 +210,45 @@ case class BspConnection(
   }
 }
 
+
+
 object BspConnectionManager {
 
   case class Handle(in: OutputStream, out: InputStream, err: InputStream) extends AutoCloseable {
+
+    lazy val errReader = new BufferedReader(new InputStreamReader(err))
+
     override def close(): Unit = {
       in.close()
       out.close()
       err.close()
     }
+  }
+
+  object HandleHandler {
+    private val handles: scala.collection.mutable.Map[Handle, PrintWriter] = scala.collection.concurrent.TrieMap()
+
+    private val ec: ExecutionContext = ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor(), throw _)
+
+    def handle(handle: Handle, sink: PrintWriter): Unit = {
+      handles(handle) = sink
+    }
+
+    Future{
+      while(true){
+        handles.foreach{
+          case (handle, sink) =>
+            try {
+              val line = handle.errReader.readLine()
+              if(line != null) sink.println(line)
+            } catch {
+              case e: IOException => e.printStackTrace(sink)
+            }
+        }
+        Thread.sleep(100)
+      }
+    }(ec)
+
   }
 
   import bloop.launcher.LauncherMain
@@ -289,9 +320,7 @@ object Compilation {
       val log = new java.io.PrintWriter(bspTraceBuffer, true)
       log.println(s"----------- ${LocalDateTime.now} --- Compilation log for ${dir.value}")
       val handle = BspConnectionManager.bloopLauncher
-      val err = new java.io.BufferedReader(new java.io.InputStreamReader(handle.err))
-      // FIXME: This surely isn't the best way to consume a stream.
-      new Thread { override def run(): Unit = Stream.continually{Thread.sleep(100); err.readLine()}.filter(_ != null).foreach(log.println) }.start()
+      BspConnectionManager.HandleHandler.handle(handle, log)
       val client = new BuildingClient(messageSink = new PrintWriter(bspMessageBuffer))
       val launcher = new Launcher.Builder[FuryBspServer]()
         .traceMessages(log)

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -497,7 +497,7 @@ case class Compilation(
   lazy val allDependencies: Set[Target] = targets.values.to[Set]
 
   def bspUpdate(io: Io, targetId: TargetId, layout: Layout): Unit =
-    Compilation.bspPool.borrow(io, layout.furyDir) { conn =>
+    Compilation.bspPool.borrow(layout.furyDir) { conn =>
       conn.provision(this, targetId, layout, None) { server =>
         server.workspaceBuildTargets.get.getTargets.asScala.toString
       }
@@ -582,7 +582,7 @@ case class Compilation(
                     multiplexer: Multiplexer[ModuleRef, CompileEvent])
                     : Future[Boolean] =
     Future { blocking {
-      Compilation.bspPool.borrow(io, layout.furyDir) { conn =>
+      Compilation.bspPool.borrow(layout.furyDir) { conn =>
         conn.provision(this, target.id, layout, Some(multiplexer)) { server =>
           val uri: String = s"file://${layout.workDir(target.id).value}?id=${target.id.key}"
           val statusCode = try {

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -223,7 +223,7 @@ object BspConnectionManager {
   import bloop.launcher.LauncherMain
   import bloop.launcher.LauncherStatus._
 
-  private val bloopVersion = "1.3.0-RC1"
+  private val bloopVersion = "1.3.2"
 
   def bloopLauncher: Handle = {
 

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -214,11 +214,12 @@ case class BspConnection(
 
 object BspConnectionManager {
 
-  case class Handle(in: OutputStream, out: InputStream, err: InputStream) extends AutoCloseable {
+  case class Handle(in: OutputStream, out: InputStream, err: InputStream, broken: Promise[Unit]) extends AutoCloseable {
 
     lazy val errReader = new BufferedReader(new InputStreamReader(err))
 
     override def close(): Unit = {
+      broken.success(())
       in.close()
       out.close()
       err.close()
@@ -237,12 +238,16 @@ object BspConnectionManager {
     Future{
       while(true){
         handles.foreach{
-          case (handle, sink) =>
+          case (handle, sink) if !handle.broken.isCompleted =>
             try {
               val line = handle.errReader.readLine()
               if(line != null) sink.println(line)
             } catch {
-              case e: IOException => e.printStackTrace(sink)
+              case e: IOException =>
+                sink.println("Broken handle!")
+                e.printStackTrace(sink)
+                handles -= handle
+                handle.broken.failure(e)
             }
         }
         Thread.sleep(100)
@@ -270,7 +275,7 @@ object BspConnectionManager {
     val err = new PipedInputStream
     err.connect(bloopErr)
 
-    val handle = Handle(in, out, err)
+    val handle = Handle(in, out, err, Promise[Unit])
 
     Future(blocking{
       val launcher = new LauncherMain(
@@ -341,7 +346,19 @@ object Compilation {
       )
       server.buildInitialize(initializeParams).get
       server.onBuildInitialized()
-      BspConnection(future, client, server, bspTraceBuffer, bspMessageBuffer)
+      val x = BspConnection(future, client, server, bspTraceBuffer, bspMessageBuffer)
+      handle.broken.future.andThen{
+        case Success(_) =>
+          log.println(s"Connection for ${dir.value} has been closed.")
+          log.flush()
+          x.future.cancel(true)
+        case Failure(e) =>
+          log.println(s"Connection for ${dir.value} is broken! Cause: ${e.getMessage}")
+          e.printStackTrace(log)
+          log.flush()
+          x.future.cancel(true)
+      }
+      x
     }
   }
 
@@ -352,7 +369,7 @@ object Compilation {
     universe    <- hierarchy.universe
     compilation <- universe.compilation(io, ref, layout)
     _           <- compilation.generateFiles(io, layout)
-    _           <- compilation.bspUpdate(io, compilation.targets(ref).id, layout)
+    _           <- compilation.bspUpdate(io, compilation.targets(ref).id, layout).recover{case x: Throwable => io.println(str"$schema --- ${x.getMessage}")}
   } yield compilation
 
   def asyncCompilation(io: Io, schema: Schema, ref: ModuleRef, layout: Layout): Future[Try[Compilation]] = synchronized {

--- a/src/core/pool.scala
+++ b/src/core/pool.scala
@@ -29,6 +29,8 @@ abstract class Pool[K, T](timeout: Long)(implicit ec: ExecutionContext) {
   case class Entry(timestamp: Long, key: K, value: T)
 
   private[this] var pool: SortedSet[Entry] = TreeSet()
+  
+  def size: Int = pool.size
 
   @tailrec
   private[this] def createOrRecycle(key: K): T = {
@@ -45,7 +47,7 @@ abstract class Pool[K, T](timeout: Long)(implicit ec: ExecutionContext) {
     if(result.isEmpty) createOrRecycle(key) else result.get
   }
 
-  def borrow[S](io: Io, key: K)(action: T => S): S = {
+  def borrow[S](key: K)(action: T => S): S = {
     val value: T = synchronized {
       pool.headOption.fold(createOrRecycle(key)) { e =>
         pool -= e

--- a/src/core/pool.scala
+++ b/src/core/pool.scala
@@ -49,7 +49,7 @@ abstract class Pool[K, T](timeout: Long)(implicit ec: ExecutionContext) {
 
   def borrow[S](key: K)(action: T => S): S = {
     val value: T = synchronized {
-      pool.headOption.fold(createOrRecycle(key)) { e =>
+      pool.find(_.key == key).fold(createOrRecycle(key)) { e =>
         pool -= e
         e.value
       }

--- a/test/passing/hello-world/script
+++ b/test/passing/hello-world/script
@@ -5,9 +5,11 @@ fury module update -C scala-lang.org:scala-compiler:2.12.8
 fury binary add -b org.scala-lang:scala-compiler:2.12.8
 fury project add -n hello-world
 fury module add -n app -c scala/compiler -t application -M HelloWorld
-fury source add -d src
 mkdir -p src
-echo 'object HelloWorld extends App { new java.io.PrintWriter("test/tmp/hello-world/.content") { write("Hello World\n"); close() } }' > src/hw.scala
+touch .content
+echo 'object HelloWorld extends App { new java.io.PrintWriter(".content") { write("Hello World\n"); close() } }' > src/hw.scala
+fury source add -d src
 timeout 180 fury build compile --output linear
 echo $?
 cat .content
+find . -name '*.class'


### PR DESCRIPTION
This pull request fixes issues #396 and #397. It also bumps the version of Bloop to 1.3.0.

Unfortunately, the Cloud build doesn't execute all the unit tests. This is a bug that needs another pull request. To run the new test suite manually, comment out all other suites in `src/core-test/Tests.scala`.
