### PR TITLE
Enabled writing message and BSP logs by default. Added a command to clean them

### DIFF
--- a/src/core/CleanCli.scala
+++ b/src/core/CleanCli.scala
@@ -29,6 +29,7 @@ object CleanCli {
     for {
       _ <- cleanBloop(ctx)
       _ <- cleanClasses(ctx)
+      _ <- cleanLogs(ctx)
       _ <- cleanRepos(ctx)
       _ <- cleanSources(ctx)
     } yield Done
@@ -42,6 +43,11 @@ object CleanCli {
   def cleanClasses(ctx: Context): Try[ExitStatus] =
     for {
       _ <- ctx.layout.classesDir.delete()
+    } yield Done
+
+  def cleanLogs(ctx: Context): Try[ExitStatus] =
+    for {
+      _ <- ctx.layout.logsDir.delete()
     } yield Done
 
   def cleanRepos(ctx: Context): Try[ExitStatus] =

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -589,10 +589,8 @@ case class Compilation(
           val statusCode =
             if(application) server.buildTargetRun(new RunParams(new BuildTargetIdentifier(uri))).get.getStatusCode
             else server.buildTargetCompile(new CompileParams(List(new BuildTargetIdentifier(uri)).asJava)).get.getStatusCode
-          if(statusCode != StatusCode.OK){
-            conn.writeTrace(layout)
-            conn.writeMessages(layout)
-          }
+          conn.writeTrace(layout)
+          conn.writeMessages(layout)
           multiplexer(target.ref) = StopStreaming
           statusCode == StatusCode.OK
         }

--- a/src/menu/menu.scala
+++ b/src/menu/menu.scala
@@ -46,6 +46,7 @@ object FuryMenu {
             Action('all, msg"clean all", CleanCli.cleanAll),
             Action('bloop, msg"clean bloop artifacts", CleanCli.cleanBloop),
             Action('classes, msg"clean compiled classes", CleanCli.cleanClasses),
+            Action('logs, msg"clean logs", CleanCli.cleanLogs),
             Action('repositories, msg"clean repositories", CleanCli.cleanRepos),
             Action('sources, msg"clean checked out sources", CleanCli.cleanSources)
         ),


### PR DESCRIPTION
Since Fury is currently not quite stable, the logs are useful more often than not.