### PR TITLE
Added recovery for build server errors.

### DIFF
--- a/src/core/exception.scala
+++ b/src/core/exception.scala
@@ -31,6 +31,7 @@ case class UnspecifiedProject()                       extends FuryException
 case class UnspecifiedModule()                        extends FuryException
 case class UnspecifiedMain(module: ModuleId)          extends FuryException
 case class GraalVMError(message: String)              extends FuryException
+case class BuildServerError(cause: Throwable)         extends FuryException
 case class InvalidKind(expected: Kind)                extends FuryException
 case class UnspecifiedRepo()                          extends FuryException
 case class ProjectConflict(ids: Set[ProjectId], h1: Hierarchy, h2: Hierarchy)       extends FuryException


### PR DESCRIPTION
The user message will look like this:
```
Total time: 53ms
Problem with the build server: 'org.eclipse.lsp4j.jsonrpc.JsonRpcException: java.io.IOException: Pipe closed'.
  at java.io.PipedInputStream.checkStateForReceive(PipedInputStream.java:260)
  at java.io.PipedInputStream.receive(PipedInputStream.java:226)
  at java.io.PipedOutputStream.write(PipedOutputStream.java:149)
  at java.io.OutputStream.write(OutputStream.java:75)
  at org.eclipse.lsp4j.jsonrpc.json.StreamMessageConsumer.consume(StreamMessageConsumer.java:67)
  at org.eclipse.lsp4j.jsonrpc.Launcher$Builder.lambda$wrapMessageConsumer$0(Launcher.java:342)
  at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.request(RemoteEndpoint.java:161)
  at org.eclipse.lsp4j.jsonrpc.services.EndpointProxy.invoke(EndpointProxy.java:91)
  at com.sun.proxy.$Proxy5.buildTargetCompile(Unknown Source)
  at fury.core.Compilation.$anonfun$compileModule$4(data.scala:639)
  at fury.core.Compilation.$anonfun$compileModule$4$adapted(data.scala:634)
  at fury.core.BspConnection.provision(data.scala:201)
  at fury.core.Compilation.$anonfun$compileModule$3(data.scala:634)
  at fury.core.Compilation.$anonfun$compileModule$3$adapted(data.scala:633)
  at fury.core.Pool.borrow(pool.scala:63)
  at fury.core.Compilation.$anonfun$compileModule$2(data.scala:633)
  at scala.runtime.java8.JFunction0$mcZ$sp.apply(JFunction0$mcZ$sp.java:23)
  at scala.concurrent.impl.ExecutionContextImpl$DefaultThreadFactory$$anon$1$$anon$2.block(ExecutionContextImpl.scala:75)
  at java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3313)
  at scala.concurrent.impl.ExecutionContextImpl$DefaultThreadFactory$$anon$1.blockOn(ExecutionContextImpl.scala:87)
  at scala.concurrent.package$.blocking(package.scala:146)
  at fury.core.Compilation.$anonfun$compileModule$1(data.scala:633)
  at scala.runtime.java8.JFunction0$mcZ$sp.apply(JFunction0$mcZ$sp.java:23)
  at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:658)
  at scala.util.Success.$anonfun$map$1(Try.scala:255)
  at scala.util.Success.map(Try.scala:213)
  at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
  at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
  at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
  at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
  at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
  at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
  at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
  at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
  at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)

```