### PR TITLE
Refactored the build save command to use fresh build results.

### DIFF
--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -212,7 +212,7 @@ object BuildCli {
                      compRes
                  }
       _ <- ~invoc(ReporterArg).toOption.getOrElse(GraphReporter).report(io, compilation, config.theme, multiplexer, System.currentTimeMillis)
-    } yield io.await(Await.result(future, duration.Duration.Inf).success)
+    } yield io.await(Await.result(future, duration.Duration.Inf).isSuccessful)
   }
 
   def getPrompt(layer: Layer, theme: Theme): Try[String] =

--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -259,7 +259,21 @@ object BuildCli {
       optModule    <- ~optModuleId.flatMap(project.modules.findBy(_).toOption)
       module       <- optModule.ascribe(UnspecifiedModule())
       compilation  <- Compilation.syncCompilation(io, schema, module.ref(project), layout)
-      _            <- compilation.saveJars(io, module.ref(project), dir in layout.pwd, layout)
+      _           <- ~compilation.checkoutAll(io, layout)
+      _           <- compilation.generateFiles(io, layout)
+      multiplexer <- ~(new Multiplexer[ModuleRef, CompileEvent](
+        compilation.targets.map(_._1).to[List]))
+      future <- ~compilation
+        .compile(io, module.ref(project), multiplexer, Map(), layout)
+        .apply(TargetId(schema.id, module.ref(project)))
+        .andThen {
+          case compRes =>
+            multiplexer.closeAll()
+            compRes
+        }
+      _ <- ~invoc(ReporterArg).toOption.getOrElse(GraphReporter).report(io, compilation, config.theme, multiplexer, System.currentTimeMillis)
+      compileSuccess <- Await.result(future, duration.Duration.Inf).asTry
+      _            <- compilation.saveJars(io, module.ref(project), Set(compileSuccess.outputDirectory), dir in layout.pwd, layout)
     } yield io.await()
   }
 

--- a/src/core/exception.scala
+++ b/src/core/exception.scala
@@ -37,6 +37,7 @@ case class UnspecifiedRepo()                          extends FuryException
 case class ProjectConflict(ids: Set[ProjectId], h1: Hierarchy, h2: Hierarchy)       extends FuryException
 case class SchemaDifferences()                        extends FuryException
 case class LauncherFailure(msg: String)               extends FuryException
+case class CompilationFailure()                       extends FuryException
 
 object ItemNotFound {
 

--- a/src/menu/recovery.scala
+++ b/src/menu/recovery.scala
@@ -89,6 +89,8 @@ want to make this change to all schemas, please add the --force/-F argument.""")
         case e: ShellFailure =>
           cli.abort(
               msg"An error occurred while running: ${e.command}${"\n\n"}${e.stdout}${"\n"}${e.stderr}")
+        case e: CompilationFailure =>
+          cli.abort(msg"Compilation failed.")
         case e: ModuleAlreadyExists =>
           cli.abort(msg"The module '${e.module}' already exists.")
         case e: ProjectAlreadyExists =>


### PR DESCRIPTION
The `classesDir` field and method in the layout still exist because Bloop seems to need a "classesDir" for its classpath magic. However, it is expected that these directories will always be empty.