### PR TITLE
Fixed the exception type of the retrying pool.

### DIFF
--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -312,7 +312,7 @@ object Compilation {
 
   private val compilationThreadPool = Executors.newCachedThreadPool()
 
-  val bspPool: Pool[Path, BspConnection] = new RetryingPool[Path, BspConnection, java.util.concurrent.ExecutionException](60000L) {
+  val bspPool: Pool[Path, BspConnection] = new RetryingPool[Path, BspConnection, BuildServerError](60000L) {
 
     def destroy(value: BspConnection): Unit = value.shutdown()
 


### PR DESCRIPTION
The pull request #413 broke the workaround for broken connections, because the actual type of the exception that gets thrown is not `ExecutionException`. See [`data.scala`](https://github.com/propensive/fury/blob/master/src/core/data.scala#L653).