### PR TITLE
[WIP] Speed up the makefile build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ dist/bundle/lib/%.jar: bootstrap/scala bootstrap/git/% dist/bundle/lib
 	mkdir -p bootstrap/lib
 	(cd bootstrap/git/$* && make)
 	cp bootstrap/git/$*/lib/$*.jar $@
+	for DEP in $(DEPS); do \
+		mkdir -p bootstrap/git/$$DEP/lib ; test -f bootstrap/git/$$DEP/lib/$*.jar || cp bootstrap/git/$*/lib/$*.jar bootstrap/git/$$DEP/lib/ ; \
+	done
+
 
 bootstrap/bin:
 	mkdir -p $@


### PR DESCRIPTION
Since most of Fury's source dependencies also depend on each other, they get rebuilt many times during the full make. After such dependency JAR has been built, it makes sense to copy it into library directories of all other source dependencies that might depend on it.