### PR TITLE
Fix Make build on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ publish: dist/install.sh
 
 dist/install.sh: dist/fury-$(VERSION).tar.gz dist/bundle/etc
 	cat etc/install.sh $< > dist/install.sh
-	sed -i "s/FURY_VERSION=test/FURY_VERSION=$(VERSION)/" dist/install.sh
+	LC_ALL=C sed -i.bak "s/FURY_VERSION=test/FURY_VERSION=$(VERSION)/" dist/install.sh
 	chmod +x dist/install.sh
 
 dist/fury-$(VERSION).tar.gz: all-jars dist/bundle/bin/fury dist/bundle/etc
@@ -70,11 +70,11 @@ dependency-jars: dist/bundle/bin/coursier dist/bundle/lib
 		cp $$JAR dist/bundle/lib/ ; \
 	done
 
-define compile-module =
-scalac -d bootstrap/bin -cp dist/bundle/lib/'*':bootstrap/bin $@/*.scala
+define compile-module
+scalac -d bootstrap/bin/ -cp dist/bundle/lib/'*':bootstrap/bin $@/*.scala
 endef
 
-pre-compile: dist/bundle/bin/launcher bootstrap/scala $(NAILGUNJARPATH) dependency-jars $(REPOS) $(foreach D,$(DEPS),dist/bundle/lib/$D.jar)
+pre-compile: bootstrap/bin dist/bundle/bin/launcher bootstrap/scala $(NAILGUNJARPATH) dependency-jars $(REPOS) $(foreach D,$(DEPS),dist/bundle/lib/$D.jar)
 
 src/strings: pre-compile
 	$(compile-module)

--- a/etc/fury
+++ b/etc/fury
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+if [ "$(uname -s)" = 'Linux' ]; then
 FURYHOME="$(dirname "$(readlink -f "$0")")/.."
+else
+FURYHOME="$(cd "$(dirname "$0")"/.. && pwd -P)"
+fi
 
 PORT="8462"
 CLASSPATH="$FURYHOME/lib/*"

--- a/etc/fury
+++ b/etc/fury
@@ -30,8 +30,9 @@ silently() {
   #See https://unix.stackexchange.com/a/181938
   #See https://stackoverflow.com/q/3838322
   #See https://www.gnu.org/software/bash/manual/html_node/Command-Grouping.html
-  TMPFILE=$(mktemp "/tmp/fury.err.XXXXXX")
+
   if [ "$DEBUG" = "1" ]; then
+    TMPFILE=$(mktemp "/tmp/fury.err.XXXXXX")
     exec 3>"$TMPFILE"
     exec 4<"$TMPFILE"
     rm "$TMPFILE"

--- a/etc/fury
+++ b/etc/fury
@@ -103,13 +103,8 @@ restartFury() {
 }
 
 startFuryStandalone() {
-  SCALA=$(coursier fetch --classpath org.scala-lang:scala-reflect:2.12.8 com.facebook:nailgun-server:1.0.0)
-  java -Dfury.home="${FURYHOME}" -cp "$SCALA:$CLASSPATH" "$MAIN" "$PORT"
-}
-
-startFuryDirect() {
-  SCALA=$(coursier fetch --classpath org.scala-lang:scala-reflect:2.12.8 com.facebook:nailgun-server:1.0.0)
-  java -Dfury.home="${FURYHOME}" -cp "$SCALA:$CLASSPATH" -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=127.0.0.1:25005 "$FURY_MAIN" "$@"
+  SCALA=$(coursier fetch --classpath org.scala-lang:scala-reflect:2.12.8)
+  java -Dfury.home="${FURYHOME}" -cp "$SCALA:$CLASSPATH" "$FURY_MAIN" "$@"
 }
 
 case "$1" in
@@ -117,10 +112,7 @@ case "$1" in
     silently startFury
     ;;
   "standalone")
-    silently startFuryStandalone
-    ;;
-  "direct")
-    silently startFuryDirect "${@:2}"
+    startFuryStandalone "${@:2}"
     ;;
   "kill")
     silently killFury "${@:2}"

--- a/src/core/bsp.scala
+++ b/src/core/bsp.scala
@@ -47,9 +47,9 @@ object Bsp {
 
     for {
       // FIXME we should use fury launch jar directly with java here
-      fury <- whichFury(layout)
+      fury   <- whichFury(layout)
       config = bspConfigJson(fury)
-      _ <- bspConfig.writeSync(config.serialize)
+      _      <- bspConfig.writeSync(config.serialize)
     } yield ()
   }
 
@@ -58,20 +58,18 @@ object Bsp {
     sh"command -v fury".exec[Try[String]].map(Path.apply)
   }
 
-  private def bspConfigJson(fury: Path): Json = {
-
+  private def bspConfigJson(fury: Path): Json =
     Json(
         name = "Fury",
         argv = List(
             fury.javaPath.toAbsolutePath.toString,
-            "direct",
+            "standalone",
             "bsp"
         ),
         version = Version.current,
         bspVersion = bspVersion,
         languages = List("java", "scala")
     )
-  }
 
   def startServer(cli: Cli[CliParam[_]]): Try[ExitStatus] =
     for {
@@ -128,7 +126,10 @@ class FuryBuildServer(layout: Layout, cancel: Cancelator)
                              universe.makeTarget(io, d, layout)
                            }.sequence
                   } yield arts.map { a =>
-                    (a.ref, (a.dependencies.map(_.ref): List[ModuleRef]) ++ (a.compiler.map(_.ref.hide): Option[ModuleRef]))
+                    (
+                        a.ref,
+                        (a.dependencies.map(_.ref): List[ModuleRef]) ++ (a.compiler
+                          .map(_.ref.hide): Option[ModuleRef]))
                   }
                 }
                 .sequence
@@ -136,8 +137,8 @@ class FuryBuildServer(layout: Layout, cancel: Cancelator)
       allModuleRefs = graph.keys
       modules       <- allModuleRefs.traverse(ref => universe.getMod(ref).map((ref, _)))
       targets <- graph.keys.map { key =>
-                    universe.makeTarget(io, key, layout).map(key -> _)
-                  }.sequence.map(_.toMap)
+                  universe.makeTarget(io, key, layout).map(key -> _)
+                }.sequence.map(_.toMap)
       checkouts <- graph.keys.map(universe.checkout(_, layout)).sequence
     } yield Structure(modules.toMap, graph, checkouts.foldLeft(Set[Checkout]())(_ ++ _), targets)
 
@@ -419,8 +420,8 @@ object FuryBuildServer {
 
     val buildTarget =
       new BuildTarget(id, tags.asJava, languageIds.asJava, dependencies.asJava, capabilities)
-    
-      buildTarget.setDisplayName(moduleRefDisplayName(ref))
+
+    buildTarget.setDisplayName(moduleRefDisplayName(ref))
 
     for {
       compiler <- target.compiler


### PR DESCRIPTION
 Fix Fury make build on mac

make build was broken through
1. non-portable sed command, incomatible with Mac/BSP sed
2. non-portable way of determining FURYHOME
3. non-portable definition of compile-module (it would simply not be executed, silently generating empty fury.jar)

Make is not a good build tool :(


Also fix generation of empty tmpfiles, and remove fury direct / change it to fury standalone