### PR TITLE
Moved the execution of application modules from Bloop to separate Java processes.

### DIFF
--- a/etc/security/fury_application_module.policy
+++ b/etc/security/fury_application_module.policy
@@ -1,5 +1,6 @@
 grant {
       permission java.io.FilePermission "${fury.sharedDir}${/}-", "read,write";
+      permission java.io.FilePermission ".${/}-", "read,write";
       permission java.lang.RuntimePermission "getenv.SHARED", "read";
       permission java.util.PropertyPermission "fury.sharedDir", "read";
       permission java.util.PropertyPermission "scala.*", "read";

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -18,9 +18,7 @@
 package fury.core
 
 import fury._, io._, strings._, ogdl._
-
-import Graph.{Compiling, CompilerDiagnostic, OtherMessage, DiagnosticMessage}
-
+import Graph.{CompilerDiagnostic, DiagnosticMessage, OtherMessage}
 import exoskeleton._
 import gastronomy._
 import kaleidoscope._
@@ -44,7 +42,7 @@ import java.io._
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.time.LocalDateTime
-import java.util.concurrent.Executors
+import java.util.concurrent.{CompletableFuture, Executors}
 
 import language.higherKinds
 
@@ -550,15 +548,17 @@ case class Compilation(graph: Map[TargetId, List[TargetId]],
       Parameter(str"Xplugin:${layout.classesDir(pluginTarget.id)}")
     }).map(_.parameter)
 
-  def jmhRuntimeClasspath(io: Io, ref: ModuleRef, layout: Layout): Set[Path] =
+  def jmhRuntimeClasspath(io: Io, ref: ModuleRef, classesDirs: Set[Path], layout: Layout): Set[Path] =
     targets(ref).compiler.to[Set].flatMap { compilerTarget =>
-      Set(layout.classesDir(compilerTarget.id), layout.resourcesDir(compilerTarget.id))
+      classesDirs + layout.resourcesDir(compilerTarget.id)
     } ++ classpath(ref, layout)
 
   def runtimeClasspath(io: Io, ref: ModuleRef, layout: Layout): Set[Path] =
     targets(ref).compiler.to[Set].flatMap { compilerTarget =>
       Set(layout.classesDir(compilerTarget.id), layout.resourcesDir(compilerTarget.id))
     } ++ classpath(ref, layout) + layout.classesDir(targets(ref).id) + layout.resourcesDir(targets(ref).id)
+
+  private case object CompilationFailed extends Exception
 
   def compileModule(io: Io,
                     target: Target,
@@ -570,36 +570,35 @@ case class Compilation(graph: Map[TargetId, List[TargetId]],
     val targetIdentifiers = deepDependencies(target.id).map { dep =>
       new BuildTargetIdentifier(s"file://${layout.workDir(dep).value}?id=${dep.key}")
     }
-    
-    Future { blocking {
-      Compilation.bspPool.borrow(layout.furyDir) { conn =>
-        conn.provision(this, target.id, layout, Some(multiplexer)) { server =>
-          val uri: String = s"file://${layout.workDir(target.id).value}?id=${target.id.key}"
-          
-          val result = try {
-            val statusCode = if(application) {
-              val params = new RunParams(new BuildTargetIdentifier(uri))
-              server.buildTargetRun(params).get.getStatusCode
-            } else {
-              val params = new CompileParams(List(new BuildTargetIdentifier(uri)).asJava)
-              server.buildTargetCompile(params).get.getStatusCode
-            }
 
-            if(statusCode == StatusCode.OK) {
-              val scalacOptions = new ScalacOptionsParams(targetIdentifiers.toList.asJava)
-              val outputDirectories = server.buildTargetScalacOptions(scalacOptions).get
-                .getItems.asScala.toSet.map { x: ScalacOptionsItem => Path(new URI(x.getClassDirectory)) }
-              
-                CompileSuccess(outputDirectories)
-            } else CompileFailure
-          } catch { case e: java.util.concurrent.ExecutionException => throw BuildServerError(e.getCause) }
-          
-          conn.writeTrace(layout)
-          conn.writeMessages(layout)
-          result
+    def wrapServerErrors[T](f: => CompletableFuture[T]): Try[T] = {
+      Outcome.rescue[java.util.concurrent.ExecutionException]{e: ExecutionException => BuildServerError(e.getCause)}(f.get)
+    }
+    
+    Future (blocking {
+      Compilation.bspPool.borrow(layout.furyDir) { conn =>
+        val result: Try[CompileResult] = conn.provision(this, target.id, layout, Some(multiplexer)) { server =>
+          val uri: String = s"file://${layout.workDir(target.id).value}?id=${target.id.key}"
+
+          val params = new CompileParams(List(new BuildTargetIdentifier(uri)).asJava)
+          val scalacOptionsParams = new ScalacOptionsParams(targetIdentifiers.toList.asJava)
+
+          (for {
+            compileResult <- wrapServerErrors(server.buildTargetCompile(params))
+            statusCode = compileResult.getStatusCode
+            _ <- if(statusCode == StatusCode.OK) ~() else Failure(CompilationFailed)
+            scalacOptions <- wrapServerErrors(server.buildTargetScalacOptions(scalacOptionsParams))
+            outputDirectories = scalacOptions.getItems.asScala.toSet.map { x: ScalacOptionsItem => Path(new URI(x.getClassDirectory)) }
+          } yield CompileSuccess(outputDirectories)).recover{
+            case CompilationFailed => CompileFailure
+          }
         }
+
+        conn.writeTrace(layout)
+        conn.writeMessages(layout)
+        result.get
       }
-    } }
+    })
   }
 
   def compile(io: Io,
@@ -630,22 +629,24 @@ case class Compilation(graph: Map[TargetId, List[TargetId]],
         }
 
         compileModule(io, target, layout, target.kind == Application, multiplexer).map {
-          case CompileSuccess(classDirectories) if target.kind == Benchmarks =>
-            classDirectories.foreach { classDirectory =>
-              Jmh.instrument(classDirectory, layout.benchmarksDir(target.id), layout.resourcesDir(target.id))
-              multiplexer(target.ref) = StartStreaming
-              val javaSources = layout.benchmarksDir(target.id).findChildren(_.endsWith(".java"))
-              
-              layout.shell.javac(
-                classpath(target.ref, layout).to[List].map(_.value),
-                classDirectory.value,
-                javaSources.map(_.value).to[List])
+          case CompileSuccess(classDirectories) if target.kind == Application || target.kind == Benchmarks =>
+            if(target.kind == Benchmarks) {
+              classDirectories.foreach { classDirectory =>
+                Jmh.instrument(classDirectory, layout.benchmarksDir(target.id), layout.resourcesDir(target.id))
+                multiplexer(target.ref) = StartStreaming
+                val javaSources = layout.benchmarksDir(target.id).findChildren(_.endsWith(".java"))
+
+                layout.shell.javac(
+                  classpath(target.ref, layout).to[List].map(_.value),
+                  classDirectory.value,
+                  javaSources.map(_.value).to[List])
+              }
             }
             
             val out = new StringBuilder()
             
             val res = layout.shell.runJava(
-              jmhRuntimeClasspath(io, target.ref, layout).to[List].map(_.value),
+              jmhRuntimeClasspath(io, target.ref, classDirectories, layout).to[List].map(_.value),
               if(target.kind == Benchmarks) "org.openjdk.jmh.Main" else target.main.getOrElse(""),
               securePolicy = target.kind == Application,
               layout
@@ -663,7 +664,6 @@ case class Compilation(graph: Map[TargetId, List[TargetId]],
               multiplexer(targetId.ref) = NoCompile(targetId.ref)
             }
             
-            multiplexer(target.ref) = StopCompile(target.ref, res)
             multiplexer.close(target.ref)
             multiplexer(target.ref) = StopStreaming
 

--- a/test/passing/fat-jar/check
+++ b/test/passing/fat-jar/check
@@ -6,6 +6,8 @@ Setting default compiler for project bar to scala/compiler
 Set current module to app
 Starting compilation of module bar/app
 Successfully compiled module bar/app
+Hello World
+
 Saving JAR file out/bar-app.jar
 0
 bar-app.jar

--- a/test/passing/hello-world/check
+++ b/test/passing/hello-world/check
@@ -6,5 +6,7 @@ Setting default compiler for project hello-world to scala/compiler
 Set current module to app
 Starting compilation of module hello-world/app
 Successfully compiled module hello-world/app
+
 0
 Hello World
+

--- a/test/passing/hello-world/script
+++ b/test/passing/hello-world/script
@@ -7,7 +7,7 @@ fury project add -n hello-world
 fury module add -n app -c scala/compiler -t application -M HelloWorld
 fury source add -d src
 mkdir -p src
-echo 'object HelloWorld extends App { new java.io.PrintWriter("test/tmp/hello-world/.content") { write("Hello World\n"); close() } }' > src/hw.scala
+echo 'object HelloWorld extends App { new java.io.PrintWriter(".content") { println("Hello World\n"); close() } }' > src/hw.scala
 timeout 180 fury build compile --output linear
 echo $?
 cat .content

--- a/test/passing/hello-world2/check
+++ b/test/passing/hello-world2/check
@@ -6,5 +6,6 @@ Setting default compiler for project hello-world2 to scala/compiler
 Set current module to app
 Starting compilation of module hello-world2/app
 Successfully compiled module hello-world2/app
+
 0
-Hello World
+Hello World 2

--- a/test/passing/hello-world2/script
+++ b/test/passing/hello-world2/script
@@ -7,7 +7,7 @@ fury project add -n hello-world2
 fury module add -n app -c scala/compiler -t application -M HelloWorld
 fury source add -d src
 mkdir -p src
-echo 'object HelloWorld extends App { new java.io.PrintWriter("test/tmp/hello-world2/.content") { write("Hello World\n"); close() } }' > src/hw.scala
+echo 'object HelloWorld extends App { new java.io.PrintWriter(".content") { write("Hello World 2\n"); close() } }' > src/hw.scala
 timeout 180 fury build compile --output linear
 echo $?
 cat .content

--- a/test/passing/save-jar/check
+++ b/test/passing/save-jar/check
@@ -9,6 +9,7 @@ Starting compilation of module foo/lib
 Successfully compiled module foo/lib
 Starting compilation of module foo/app
 Successfully compiled module foo/app
+
 Saving JAR file out/foo-app.jar
 0
 foo-app.jar

--- a/test/passing/save-jar/script
+++ b/test/passing/save-jar/script
@@ -12,7 +12,7 @@ fury module add -n app -c scala/compiler -t application -M HelloWorld
 fury dependency add -l lib
 mkdir -p src/app
 fury source add -d src/app
-echo 'object HelloWorld extends App { new java.io.PrintWriter("test/tmp/save-jar/.content") { write(Constants.text); close() } }' > src/app/hw.scala
+echo 'object HelloWorld extends App { new java.io.PrintWriter(".content") { write(Constants.text); close() } }' > src/app/hw.scala
 mkdir -p out
 timeout 180 fury build save --dir out --output linear
 echo $?


### PR DESCRIPTION
This change should fix the issue with application modules being executed in the wrong working directory. It also allows to use environment variables in the application modules.

However, executing application modules in separate processes requires careful tuning of security policies for these processes, which hasn't been implemented so far. 