### PR TITLE
Revert "Removed the redundant newline which was being added to the output of runJava."

### DIFF
--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -696,6 +696,7 @@ case class Compilation(graph: Map[TargetId, List[TargetId]],
               if(target.kind == Benchmarks) multiplexer(target.ref) = Print(ln)
               else {
                 out.append(ln)
+                out.append("\n")
               }
             }.await() == 0
           

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -700,7 +700,9 @@ case class Compilation(graph: Map[TargetId, List[TargetId]],
               }
             }.await() == 0
           
-            multiplexer(target.ref) = DiagnosticMsg(target.ref, OtherMessage(out.mkString))
+            if(!out.isEmpty){
+              multiplexer(target.ref) = DiagnosticMsg(target.ref, OtherMessage(out.mkString))
+            }
             
             deepDependencies(target.id).foreach { targetId =>
               multiplexer(targetId.ref) = NoCompile(targetId.ref)

--- a/test/passing/fat-jar/check
+++ b/test/passing/fat-jar/check
@@ -7,6 +7,7 @@ Set current module to app
 Starting compilation of module bar/app
 Successfully compiled module bar/app
 Hello World
+
 Saving JAR file out/bar-app.jar
 0
 bar-app.jar

--- a/test/passing/hello-world/check
+++ b/test/passing/hello-world/check
@@ -9,3 +9,4 @@ Successfully compiled module hello-world/app
 
 0
 Hello World
+

--- a/test/passing/hello-world/check
+++ b/test/passing/hello-world/check
@@ -6,7 +6,6 @@ Setting default compiler for project hello-world to scala/compiler
 Set current module to app
 Starting compilation of module hello-world/app
 Successfully compiled module hello-world/app
-
 0
 Hello World
 

--- a/test/passing/hello-world/script
+++ b/test/passing/hello-world/script
@@ -7,7 +7,7 @@ fury project add -n hello-world
 fury module add -n app -c scala/compiler -t application -M HelloWorld
 fury source add -d src
 mkdir -p src
-echo 'object HelloWorld extends App { new java.io.PrintWriter(".content") { println("Hello World"); close() } }' > src/hw.scala
+echo 'object HelloWorld extends App { new java.io.PrintWriter(".content") { println("Hello World\n"); close() } }' > src/hw.scala
 timeout 180 fury build compile --output linear
 echo $?
 cat .content

--- a/test/passing/hello-world2/check
+++ b/test/passing/hello-world2/check
@@ -6,6 +6,5 @@ Setting default compiler for project hello-world2 to scala/compiler
 Set current module to app
 Starting compilation of module hello-world2/app
 Successfully compiled module hello-world2/app
-
 0
 Hello World 2

--- a/test/passing/hello-world2/script
+++ b/test/passing/hello-world2/script
@@ -7,7 +7,7 @@ fury project add -n hello-world2
 fury module add -n app -c scala/compiler -t application -M HelloWorld
 fury source add -d src
 mkdir -p src
-echo 'object HelloWorld extends App { new java.io.PrintWriter(".content") { println("Hello World 2"); close() } }' > src/hw.scala
+echo 'object HelloWorld extends App { new java.io.PrintWriter(".content") { write("Hello World 2\n"); close() } }' > src/hw.scala
 timeout 180 fury build compile --output linear
 echo $?
 cat .content

--- a/test/passing/save-jar/check
+++ b/test/passing/save-jar/check
@@ -9,7 +9,6 @@ Starting compilation of module foo/lib
 Successfully compiled module foo/lib
 Starting compilation of module foo/app
 Successfully compiled module foo/app
-
 Saving JAR file out/foo-app.jar
 0
 foo-app.jar

--- a/test/passing/save-jar/script
+++ b/test/passing/save-jar/script
@@ -7,12 +7,12 @@ fury project add -n foo
 fury module add -n lib -c scala/compiler
 mkdir -p src/lib
 fury source add -d src/lib
-echo 'object Constants { val text = "Hello World" }' > src/lib/constants.scala
+echo 'object Constants { val text = "Hello World\n" }' > src/lib/constants.scala
 fury module add -n app -c scala/compiler -t application -M HelloWorld
 fury dependency add -l lib
 mkdir -p src/app
 fury source add -d src/app
-echo 'object HelloWorld extends App { new java.io.PrintWriter(".content") { println(Constants.text); close() } }' > src/app/hw.scala
+echo 'object HelloWorld extends App { new java.io.PrintWriter(".content") { write(Constants.text); close() } }' > src/app/hw.scala
 mkdir -p out
 timeout 180 fury build save --dir out --output linear
 echo $?


### PR DESCRIPTION
This reverts commit e54e796064a41ec8bd8091231e250edc15743f4b.

Apparently, that newline was needed, because now Fury glues all the output lines into a single line. This is most visible in stack traces.