### PR TITLE
[WIP] Allow addition of new permission requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ dist/fury-$(VERSION).tar.gz: all-jars dist/bundle/bin/fury dist/bundle/etc
 #TODO refactor etc structure (separate bundled scripts from development ones)
 dist/bundle/etc:
 	mkdir -p $@
-	cp -r etc/aliases etc/bashrc etc/fishrc etc/zshrc etc/completion etc/security $@
+	cp -r etc/aliases etc/bashrc etc/fishrc etc/zshrc etc/completion $@
 
 # Compilation
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ JARS:= $(DEPENDENCY_JARS) dist/bundle/lib/fury.jar
 NATIVEJARS=$(JARS) $(NAILGUNJARPATH) $(LIBS)
 SRCS:=$(shell find $(PWD)/src -type f -name '*.scala')
 DOCKER_TAG=fury-ci
-TESTDEPS=ogdl core
+TESTDEPS=ogdl core strings
 TESTS=$(foreach DEP, $(TESTDEPS), $(DEP)-test)
 export PATH := $(PWD)/bootstrap/scala/bin:$(PATH)
 

--- a/etc/security/fury_application_module.policy
+++ b/etc/security/fury_application_module.policy
@@ -1,6 +1,0 @@
-grant {
-      permission java.io.FilePermission "${fury.sharedDir}${/}-", "read,write";
-      permission java.io.FilePermission ".${/}-", "read,write";
-      permission java.lang.RuntimePermission "getenv.*", "read";
-      permission java.util.PropertyPermission "*", "read";
-};

--- a/layer.fury
+++ b/layer.fury
@@ -19,6 +19,9 @@ schemas	default	id	default
 						binaries	
 						resources	
 						bloopSpec	None
+						environment	
+						properties	
+						policy	
 					core	id	core
 						kind	Library
 						main	None
@@ -100,6 +103,9 @@ schemas	default	id	default
 								version	1.0.0
 						resources	
 						bloopSpec	None
+						environment	
+						properties	
+						policy	
 					dependency	id	dependency
 						kind	Library
 						main	None
@@ -118,6 +124,9 @@ schemas	default	id	default
 						binaries	
 						resources	
 						bloopSpec	None
+						environment	
+						properties	
+						policy	
 					imports	id	imports
 						kind	Library
 						main	None
@@ -136,6 +145,9 @@ schemas	default	id	default
 						binaries	
 						resources	
 						bloopSpec	None
+						environment	
+						properties	
+						policy	
 					io	id	io
 						kind	Library
 						main	None
@@ -162,6 +174,9 @@ schemas	default	id	default
 						binaries	
 						resources	
 						bloopSpec	None
+						environment	
+						properties	
+						policy	
 					jsongen	id	jsongen
 						kind	Library
 						main	None
@@ -180,6 +195,9 @@ schemas	default	id	default
 						binaries	
 						resources	
 						bloopSpec	None
+						environment	
+						properties	
+						policy	
 					menu	id	menu
 						kind	Library
 						main	None
@@ -229,6 +247,9 @@ schemas	default	id	default
 								version	1.0.0
 						resources	
 						bloopSpec	None
+						environment	
+						properties	
+						policy	
 					module	id	module
 						kind	Library
 						main	None
@@ -247,6 +268,9 @@ schemas	default	id	default
 						binaries	
 						resources	
 						bloopSpec	None
+						environment	
+						properties	
+						policy	
 					ogdl	id	ogdl
 						kind	Library
 						main	None
@@ -273,6 +297,9 @@ schemas	default	id	default
 						binaries	
 						resources	
 						bloopSpec	None
+						environment	
+						properties	
+						policy	
 					project	id	project
 						kind	Library
 						main	None
@@ -291,6 +318,9 @@ schemas	default	id	default
 						binaries	
 						resources	
 						bloopSpec	None
+						environment	
+						properties	
+						policy	
 					repo	id	repo
 						kind	Library
 						main	None
@@ -309,6 +339,9 @@ schemas	default	id	default
 						binaries	
 						resources	
 						bloopSpec	None
+						environment	
+						properties	
+						policy	
 					schema	id	schema
 						kind	Library
 						main	None
@@ -327,6 +360,9 @@ schemas	default	id	default
 						binaries	
 						resources	
 						bloopSpec	None
+						environment	
+						properties	
+						policy	
 					source	id	source
 						kind	Library
 						main	None
@@ -345,6 +381,9 @@ schemas	default	id	default
 						binaries	
 						resources	
 						bloopSpec	None
+						environment	
+						properties	
+						policy	
 					strings	id	strings
 						kind	Library
 						main	None
@@ -360,6 +399,105 @@ schemas	default	id	default
 						binaries	
 						resources	
 						bloopSpec	None
+						environment	
+						properties	
+						policy	
+					test	id	test
+						kind	Library
+						main	None
+						plugin	None
+						manifest	
+						compiler	projectId	scala
+							moduleId	compiler
+							intransitive	true
+							hidden	false
+						after	fury/test-core	projectId	fury
+								moduleId	test-core
+								intransitive	false
+								hidden	false
+						params	
+						sources	
+						binaries	
+						resources	
+						bloopSpec	None
+						environment	
+						properties	
+						policy	
+					test-core	id	test-core
+						kind	Application
+						main	Some	fury.Tests
+						plugin	None
+						manifest	
+						compiler	projectId	scala
+							moduleId	compiler
+							intransitive	true
+							hidden	false
+						after	fury/core	projectId	fury
+								moduleId	core
+								intransitive	false
+								hidden	false
+							fury/test-ogdl	projectId	fury
+								moduleId	test-ogdl
+								intransitive	false
+								hidden	false
+						params	
+						sources	src/core-test	src/core-test
+						binaries	
+						resources	
+						bloopSpec	None
+						environment	
+						properties	
+						policy	
+					test-ogdl	id	test-ogdl
+						kind	Application
+						main	Some	fury.Tests
+						plugin	None
+						manifest	
+						compiler	projectId	scala
+							moduleId	compiler
+							intransitive	true
+							hidden	false
+						after	fury/ogdl	projectId	fury
+								moduleId	ogdl
+								intransitive	false
+								hidden	false
+							fury/test-strings	projectId	fury
+								moduleId	test-strings
+								intransitive	false
+								hidden	false
+						params	
+						sources	src/ogdl-test	src/ogdl-test
+						binaries	
+						resources	
+						bloopSpec	None
+						environment	
+						properties	
+						policy	
+					test-strings	id	test-strings
+						kind	Application
+						main	Some	fury.StringsTests
+						plugin	None
+						manifest	
+						compiler	projectId	scala
+							moduleId	compiler
+							intransitive	true
+							hidden	false
+						after	fury/strings	projectId	fury
+								moduleId	strings
+								intransitive	false
+								hidden	false
+							probably/cli	projectId	probably
+								moduleId	cli
+								intransitive	false
+								hidden	false
+						params	
+						sources	src/strings-test	src/strings-test
+						binaries	
+						resources	
+						bloopSpec	None
+						environment	
+						properties	
+						policy	
 				main	Some	menu
 				license	apache-2.0
 				description	
@@ -388,6 +526,9 @@ schemas	default	id	default
 						bloopSpec	Some	org	scala-lang.org
 								name	scala-compiler
 								version	2.12.8
+						environment	
+						properties	
+						policy	
 				main	Some	compiler
 				license	unknown
 				description	
@@ -400,10 +541,16 @@ schemas	default	id	default
 			platform	id	platform
 				repo	git@github.com:propensive/platform.git
 				track	master
-				commit	58e4963d98007da74593ff0ee74c654e63663dd2
+				commit	e4fbf14f16e7c70a5e8a2bbfb6b47687cf1c20da
 				local	None
 		imports	platform:default	repo	platform
 				schema	default
 		main	Some	fury
 main	default
-aliases	
+aliases	test	cmd	test
+		description	run the Fury tests
+		schema	None
+		module	projectId	fury
+			moduleId	test
+			intransitive	false
+			hidden	false

--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -186,7 +186,8 @@ object BuildCli {
       _            <- compilation.generateFiles(io, layout)
       debugStr     <- ~invoc(DebugArg).toOption
       multiplexer  <- ~(new Multiplexer[ModuleRef, CompileEvent](compilation.targets.map(_._1).to[List]))
-      future       <- ~compilation.compile(io, module.ref(project), multiplexer, Map(), layout)
+      globalPolicy <- GlobalPolicy.read(io, cli.globalLayout)
+      future       <- ~compilation.compile(io, module.ref(project), multiplexer, Map(), layout, globalPolicy)
                         .apply(TargetId(schema.id, module.ref(project))).andThen { case compRes =>
                           multiplexer.closeAll()
                           compRes
@@ -239,8 +240,10 @@ object BuildCli {
       _              <- ~compilation.checkoutAll(io, layout)
       _              <- compilation.generateFiles(io, layout)
       multiplexer    <- ~(new Multiplexer[ModuleRef, CompileEvent](compilation.targets.map(_._1).to[List]))
-      future         <- ~compilation.compile(io, module.ref(project), multiplexer, Map(), layout).apply(
-                            TargetId(schema.id, module.ref(project))).andThen { case compRes =>
+      globalPolicy   <- GlobalPolicy.read(io, cli.globalLayout)
+      future         <- ~compilation.compile(io, module.ref(project), multiplexer, Map(), layout,
+                            globalPolicy).apply(TargetId(schema.id,
+                            module.ref(project))).andThen { case compRes =>
                           multiplexer.closeAll()
                           compRes
                         }

--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -115,12 +115,11 @@ object AliasCli {
 
 object BuildCli {
 
-  def context(cli: Cli[CliParam[_]]): Try[MenuContext] =
-    for {
-      layout <- cli.layout
-      config <- Config.read()(cli.env, cli.globalLayout)
-      layer  <- Layer.read(Io.silent(config), layout.furyConfig, layout)
-    } yield new MenuContext(cli, layout, config, layer)
+  def context(cli: Cli[CliParam[_]]): Try[MenuContext] = for {
+    layout <- cli.layout
+    config <- Config.read()(cli.env, cli.globalLayout)
+    layer  <- Layer.read(Io.silent(config), layout.furyConfig, layout)
+  } yield new MenuContext(cli, layout, config, layer)
 
   def notImplemented(cli: Cli[CliParam[_]]): Try[ExitStatus] = Success(Abort)
 
@@ -157,11 +156,9 @@ object BuildCli {
     } yield Done
   }
 
-  def compile(
-      optSchema: Option[SchemaId],
-      moduleRef: Option[ModuleRef]
-    )(ctx: MenuContext
-    ): Try[ExitStatus] = {
+  def compile(optSchema: Option[SchemaId], moduleRef: Option[ModuleRef])
+             (ctx: MenuContext)
+             : Try[ExitStatus] = {
     import ctx._
     for {
       cli          <- cli.hint(SchemaArg, layer.schemas)
@@ -186,7 +183,7 @@ object BuildCli {
       _            <- compilation.generateFiles(io, layout)
       debugStr     <- ~invoc(DebugArg).toOption
       multiplexer  <- ~(new Multiplexer[ModuleRef, CompileEvent](compilation.targets.map(_._1).to[List]))
-      globalPolicy <- GlobalPolicy.read(io, cli.globalLayout)
+      globalPolicy <- Policy.read(io, cli.globalLayout)
       future       <- ~compilation.compile(io, module.ref(project), multiplexer, Map(), layout, globalPolicy)
                         .apply(TargetId(schema.id, module.ref(project))).andThen { case compRes =>
                           multiplexer.closeAll()
@@ -240,7 +237,7 @@ object BuildCli {
       _              <- ~compilation.checkoutAll(io, layout)
       _              <- compilation.generateFiles(io, layout)
       multiplexer    <- ~(new Multiplexer[ModuleRef, CompileEvent](compilation.targets.map(_._1).to[List]))
-      globalPolicy   <- GlobalPolicy.read(io, cli.globalLayout)
+      globalPolicy   <- Policy.read(io, cli.globalLayout)
       future         <- ~compilation.compile(io, module.ref(project), multiplexer, Map(), layout,
                             globalPolicy).apply(TargetId(schema.id,
                             module.ref(project))).andThen { case compRes =>
@@ -326,16 +323,15 @@ object BuildCli {
 }
 
 object LayerCli {
-  def init(cli: Cli[CliParam[_]]): Try[ExitStatus] =
-    for {
-      layout <- cli.newLayout
-      invoc  <- cli.read()
-      io     <- invoc.io()
-      layer  <- ~Layer()
-      _      <- layout.furyConfig.mkParents()
-      _      <- ~Layer.save(io, layer, layout)
-      _      <- ~io.println("Created empty layer.fury")
-    } yield io.await()
+  def init(cli: Cli[CliParam[_]]): Try[ExitStatus] = for {
+    layout <- cli.newLayout
+    invoc  <- cli.read()
+    io     <- invoc.io()
+    layer  <- ~Layer()
+    _      <- layout.furyConfig.mkParents()
+    _      <- ~Layer.save(io, layer, layout)
+    _      <- ~io.println("Created empty layer.fury")
+  } yield io.await()
 
   def projects(cli: Cli[CliParam[_]]): Try[ExitStatus] = for {
     layout    <- cli.layout

--- a/src/core/args.scala
+++ b/src/core/args.scala
@@ -44,8 +44,10 @@ object Args {
 
   val BinaryRepoArg = CliParam[BinRepoId]('r', 'repo, "Specify the repository from which to fetch binaries")
   val AliasArg = CliParam[AliasCmd]('a', 'alias, "specify a command alias")
+  val ActionArg = CliParam[String]('A', 'action, "specify a permission action")
   val BinaryArg = CliParam[String]('b', 'binary, "specify a binary dependency")
   val CompilerArg = CliParam[String]('c', 'compiler, "specify a compiler")
+  val ClassArg = CliParam[String]('C', 'class, "specify a class name")
   val DefaultCompilerArg = CliParam[String]('c', 'compiler, "specify a default compiler")
   val LinkArg = CliParam[String]('l', 'link, "specify a dependency link to another module")
   val SourceArg = CliParam[String]('d', 'source, "specify a source directory")
@@ -87,6 +89,7 @@ object Args {
   val ReporterArg = CliParam[Reporter]('o', 'output, s"format for build output ($allReporters)")
   val SchemaArg = CliParam[SchemaId]('s', 'schema, "specify a schema")
   val TargetArg = CliParam[String]('T', 'target, "target file/directory")
+  val PermissionTargetArg = CliParam[String]('T', 'target, "permission target")
   val TagArg = CliParam[String]('t', 'tag, "git tag")
   val ThemeArg = CliParam[Theme]('T', 'theme, "specify a color theme")
   val UrlArg = CliParam[String]('u', 'url, "specify a URL")

--- a/src/core/args.scala
+++ b/src/core/args.scala
@@ -39,6 +39,7 @@ object Args {
   implicit private val version: TExtractor[RefSpec] = _.headOption.map(RefSpec(_))
   implicit private val theme: TExtractor[Theme] = _.headOption.flatMap(Theme.unapply(_))
   implicit private val reporter: TExtractor[Reporter] = _.headOption.flatMap(Reporter.unapply(_))
+  implicit private val scopeId: TExtractor[ScopeId] = _.headOption.flatMap(ScopeId.unapply(_))
 
   val AllArg = CliParam[Unit]('a', 'all, "update all repositories")
 
@@ -79,6 +80,7 @@ object Args {
 
   val ProjectArg = CliParam[ProjectId]('p', 'project, "specify a project")
   val ParamArg = CliParam[Parameter]('P', 'param, "compiler parameter")
+  val PermissionArg = CliParam[String]('P', 'permission, "permission entry")
   val PropArg = CliParam[JavaProperty]('D', 'param, "Java -D property")
   val QuietArg = CliParam[Unit]('q', 'quiet, "show less output")
   val RepoArg = CliParam[RepoId]('r', 'repo, "specify a repository")
@@ -88,6 +90,7 @@ object Args {
   private val allReporters = Reporter.all.map(_.name).mkString(", ")
   val ReporterArg = CliParam[Reporter]('o', 'output, s"format for build output ($allReporters)")
   val SchemaArg = CliParam[SchemaId]('s', 'schema, "specify a schema")
+  val ScopeArg = CliParam[ScopeId]('S', 'scope, "specify the permission scope (layer, directory, project)")
   val TargetArg = CliParam[String]('T', 'target, "target file/directory")
   val PermissionTargetArg = CliParam[String]('T', 'target, "permission target")
   val TagArg = CliParam[String]('t', 'tag, "git tag")

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -210,7 +210,8 @@ case class Policy(policy: SortedSet[Grant] = TreeSet()) {
     sb.append("grant {\n")
     policy.foreach { grant =>
       val p = grant.permission
-      sb.append(str""" permission ${p.className} "${p.target}"${p.action.fold("") { a => """, "$a\"""" }};\n""")
+      val actionAddendum = p.action.fold("") { a => s""", "$a"""" }
+      sb.append(str""" permission ${p.className} "${p.target}"${actionAddendum};""")
       sb.append('\n')
     }
     sb.append("};\n")

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -183,26 +183,26 @@ object Grant {
 
 case class Grant(scope: Scope, permission: Permission)
 
-object GlobalPolicy {
-  def read(io: Io, layout: GlobalLayout): Try[GlobalPolicy] =
-    Success(Ogdl.read[GlobalPolicy](layout.policyFile,
-        upgrade(io, layout, _)).toOption.getOrElse(GlobalPolicy(SortedSet.empty[Grant])))
+object Policy {
+  def read(io: Io, layout: GlobalLayout): Try[Policy] =
+    Success(Ogdl.read[Policy](layout.policyFile,
+        upgrade(io, layout, _)).toOption.getOrElse(Policy(SortedSet.empty[Grant])))
 
-  def save(io: Io, layout: GlobalLayout, policy: GlobalPolicy): Try[Unit] =
+  def save(io: Io, layout: GlobalLayout, policy: Policy): Try[Unit] =
     layout.policyFile.writeSync(Ogdl.serialize(Ogdl(policy)))
   
   private def upgrade(io: Io, layout: GlobalLayout, ogdl: Ogdl): Ogdl = ogdl
 }
 
-case class GlobalPolicy(policy: SortedSet[Grant] = TreeSet()) {
-  def forContext(layout: Layout, projectId: ProjectId/*, layer: Layer*/): GlobalPolicy =
-    GlobalPolicy(policy.filter {
+case class Policy(policy: SortedSet[Grant] = TreeSet()) {
+  def forContext(layout: Layout, projectId: ProjectId/*, layer: Layer*/): Policy =
+    Policy(policy.filter {
       case Grant(DirectoryScope(dir), _) => dir == layout.base.value
       case Grant(ProjectScope(id), _)    => projectId == id
       //case Grant(LayerScope(hash), _)    => hash == layer.hash
     })
 
-  def grant(scope: Scope, permission: Permission): GlobalPolicy =
+  def grant(scope: Scope, permission: Permission): Policy =
     copy(policy = policy + Grant(scope, permission))
   
   def save(file: Path): Try[Unit] = file.writeSync {
@@ -771,7 +771,7 @@ case class Compilation(graph: Map[TargetId, List[TargetId]],
               multiplexer: Multiplexer[ModuleRef, CompileEvent],
               futures: Map[TargetId, Future[CompileResult]] = Map(),
               layout: Layout,
-              globalPolicy: GlobalPolicy)
+              globalPolicy: Policy)
              : Map[TargetId, Future[CompileResult]] = {
     val target = targets(moduleRef)
     

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -101,13 +101,45 @@ case class Binary(binRepo: BinRepoId, group: String, artifact: String, version: 
 }
 
 object Permission {
-  implicit val msgShow: MsgShow[Permission] = p => msg"""${p.className} "${p.context}", "${p.permission}";"""
-  implicit val stringShow: StringShow[Permission] =
-    p => str"""${p.className} "${p.context}", "${p.permission}";"""
+  implicit val msgShow: MsgShow[Permission] = stringShow.show
+  
+  implicit val stringShow: StringShow[Permission] = p =>
+    str"""${p.className} "${p.context}"${p.permission.fold("") { p => s""", "$p"""" }}";"""
   
   implicit def diff: Diff[Permission] = Diff.gen[Permission]
+
+  val Classes: List[String] = List(
+    "java.awt.AWTPermission",
+    "java.io.FilePermission",
+    "java.io.SerializablePermission",
+    "java.lang.management.ManagementPermission",
+    "java.lang.reflect.ReflectPermission",
+    "java.lang.RuntimePermission",
+    "java.net.NetPermission",
+    "java.net.SocketPermission",
+    "java.net.URLPermission",
+    "java.nio.file.LinkPermission",
+    "java.security.AllPermission",
+    "java.security.SecurityPermission",
+    "java.security.UnresolvedPermission",
+    "java.sql.SQLPermission",
+    "java.util.logging.LoggingPermission",
+    "java.util.PropertyPermission",
+    "javax.management.MBeanPermission",
+    "javax.management.MBeanServerPermission",
+    "javax.management.MBeanTrustPermission",
+    "javax.management.remote.SubjectDelegationPermission",
+    "javax.net.ssl.SSLPermission",
+    "javax.security.auth.AuthPermission",
+    "javax.security.auth.kerberos.DelegationPermission",
+    "javax.security.auth.kerberos.ServicePermission",
+    "javax.security.auth.PrivateCredentialPermission",
+    "javax.sound.sampled.AudioPermission",
+    "javax.xml.bind.JAXBPermission",
+    "javax.xml.ws.WebServicePermission"
+  )
 }
-case class Permission(className: String, context: String, permission: String)
+case class Permission(className: String, context: String, permission: Option[String])
 
 object EnvVar {
   implicit val msgShow: MsgShow[EnvVar] = e => msg"${e.key}=${e.value}"

--- a/src/core/layout.scala
+++ b/src/core/layout.scala
@@ -44,9 +44,10 @@ object Layout {
 }
 
 case class GlobalLayout(home: Path) {
-  private[this] val userDir    = (home / ".furyrc").extant()
-  lazy val userConfig: Path    = userDir / "config.fury"
-  lazy val aliasesPath: Path   = userDir / "aliases"
+  private[this] val userDir = (home / ".furyrc").extant()
+  lazy val userConfig: Path = userDir / "config.fury"
+  lazy val aliasesPath: Path = userDir / "aliases"
+  lazy val policyFile: Path = userDir / "policy.fury"
 }
 
 case class Layout(home: Path, pwd: Path, env: Environment, base: Path) {

--- a/src/core/layout.scala
+++ b/src/core/layout.scala
@@ -67,6 +67,7 @@ case class Layout(home: Path, pwd: Path, env: Environment, base: Path) {
   lazy val srcsDir: Path = (userDir / "sources").extant()
   lazy val logsDir: Path = (furyDir / "logs").extant()
   lazy val workDir: Path = (furyDir / "work").extant()
+  lazy val policyDir: Path = (furyDir / "policy").extant()
   lazy val sharedDir: Path = (furyDir / "build" / uniqueId).extant()
   lazy val errorLogfile: Path = logsDir.extant() / s"$nowString-$uniqueId.log"
   lazy val messagesLogfile: Path = logsDir.extant() / s"$nowString-$uniqueId.bsp-messages.log"

--- a/src/core/lenses.scala
+++ b/src/core/lenses.scala
@@ -158,6 +158,10 @@ object Lenses {
                    : Lens[Layer, SortedSet[EnvVar], SortedSet[EnvVar]] =
       lens(_.schemas(on(schemaId)).projects(on(projectId)).modules(on(moduleId)).environment)
 
+    def policy(schemaId: SchemaId, projectId: ProjectId, moduleId: ModuleId)
+                   : Lens[Layer, SortedSet[Permission], SortedSet[Permission]] =
+      lens(_.schemas(on(schemaId)).projects(on(projectId)).modules(on(moduleId)).policy)
+
     def properties(schemaId: SchemaId, projectId: ProjectId, moduleId: ModuleId)
                    : Lens[Layer, SortedSet[JavaProperty], SortedSet[JavaProperty]] =
       lens(_.schemas(on(schemaId)).projects(on(projectId)).modules(on(moduleId)).properties)

--- a/src/core/shell.scala
+++ b/src/core/shell.scala
@@ -38,7 +38,7 @@ case class Shell(environment: Environment) {
               securePolicy: Boolean,
               env: Map[String, String],
               properties: Map[String, String],
-              policy: GlobalPolicy,
+              policy: Policy,
               layout: Layout)
              (output: String => Unit)
              : Running = {

--- a/src/core/shell.scala
+++ b/src/core/shell.scala
@@ -25,11 +25,11 @@ import scala.util._
 import scala.collection.mutable.HashMap
 
 import java.io.FileOutputStream
+import java.util.UUID
 import java.util.jar.{JarOutputStream, Manifest => JManifest}
 
 case class Shell(environment: Environment) {
   private val furyHome   = Path(System.getProperty("fury.home"))
-  private val policyFile = furyHome / "etc" / "security" / "fury_application_module.policy"
 
   implicit private[this] val defaultEnvironment: Environment = environment
 
@@ -38,6 +38,7 @@ case class Shell(environment: Environment) {
               securePolicy: Boolean,
               env: Map[String, String],
               properties: Map[String, String],
+              policy: GlobalPolicy,
               layout: Layout)
              (output: String => Unit)
              : Running = {
@@ -46,8 +47,11 @@ case class Shell(environment: Environment) {
     implicit val defaultEnvironment: Environment =
       Environment((environment.variables ++ env).updated("SHARED", layout.sharedDir.value), environment.workDir)
 
+    val policyFile = layout.policyDir / UUID.randomUUID().toString
+    policy.save(policyFile)
+
     val allProperties: Map[String, String] =
-      properties.updated("java.security.manager", "").updated("java.security.policy",policyFile.value)
+      properties.updated("java.security.manager", "").updated("java.security.policy", policyFile.value)
           .updated("fury.sharedDir", layout.sharedDir.value)
 
     val propArgs = allProperties.map { case (k, v) => if(v.isEmpty) str"-D$k" else str"-D$k=$v" }.to[List]

--- a/src/core/tables.scala
+++ b/src/core/tables.scala
@@ -114,6 +114,13 @@ case class Tables(config: Config) {
     Heading("PARAM", _.name)
   )
 
+  val permissions: Tabulation[PermissionEntry] = Tabulation(
+    Heading("HASH", _.hash),
+    Heading("CLASS", _.permission.className),
+    Heading("TARGET", _.permission.target),
+    Heading("ACTION", _.permission.action.getOrElse("-")),
+  )
+
   val envs: Tabulation[EnvVar] = Tabulation(
     Heading("KEY", _.key),
     Heading("VALUE", _.value)

--- a/src/dependency/dependency.scala
+++ b/src/dependency/dependency.scala
@@ -341,9 +341,9 @@ object PermissionCli {
       module   <- optModule.ascribe(UnspecifiedModule())
       permHash <- invoc(PermissionArg).map(PermissionHash(_))
       entry    <- module.policyEntries.find(_.hash == permHash).ascribe(ItemNotFound(permHash))
-      policy   <- GlobalPolicy.read(io, cli.globalLayout)
+      policy   <- Policy.read(io, cli.globalLayout)
       policy   <- ~policy.grant(Scope(scopeId, layout, layer, project), entry.permission)
-      _        <- ~GlobalPolicy.save(io, cli.globalLayout, policy)
+      _        <- ~Policy.save(io, cli.globalLayout, policy)
     } yield io.await()
   }
 

--- a/src/menu/menu.scala
+++ b/src/menu/menu.scala
@@ -85,9 +85,10 @@ object FuryMenu {
             Action('list, msg"list compiler parameters for the module", ParamCli.list)
         ),
         Menu('permission, msg"manage application permissions", PermissionCli.context, 'list)(
+            Action('grant, msg"grant an application permissions on your system", PermissionCli.grant),
+            Action('list, msg"list application permissions", PermissionCli.list),
+            Action('obviate, msg"remove an application permission", PermissionCli.obviate),
             Action('require, msg"add an application permission", PermissionCli.require),
-            //Action('obviate, msg"remove an application permission", PermissionCli.obviate),
-            //Action('list, msg"list application permissions", PermissionCli.list)
         ),
         Menu('project, msg"manage projects", ProjectCli.context, 'list)(
             Action('add, msg"add a new project to the schema", ProjectCli.add),

--- a/src/menu/menu.scala
+++ b/src/menu/menu.scala
@@ -84,6 +84,11 @@ object FuryMenu {
             Action('remove, msg"remove a compiler parameter from the module", ParamCli.remove),
             Action('list, msg"list compiler parameters for the module", ParamCli.list)
         ),
+        Menu('permission, msg"manage application permissions", PermissionCli.context, 'list)(
+            Action('require, msg"add an application permission", PermissionCli.require),
+            //Action('obviate, msg"remove an application permission", PermissionCli.obviate),
+            //Action('list, msg"list application permissions", PermissionCli.list)
+        ),
         Menu('project, msg"manage projects", ProjectCli.context, 'list)(
             Action('add, msg"add a new project to the schema", ProjectCli.add),
             Action('remove, msg"remove a project from the schema", ProjectCli.remove),

--- a/src/ogdl/ogdl.scala
+++ b/src/ogdl/ogdl.scala
@@ -85,9 +85,7 @@ object Ogdl {
 
   def write[T: OgdlWriter](value: T, path: Path): Try[Unit] =
     Outcome.rescue[IOException](FileWriteError(path)) {
-      val bak = path.rename { f =>
-        s".$f.bak"
-      }
+      val bak = path.rename { f => s".$f.bak" }
       if(path.exists()) path.copyTo(bak)
       val sb = new StringBuilder()
       Ogdl.serialize(sb, implicitly[OgdlWriter[T]].write(value))

--- a/src/strings-test/prefixes.scala
+++ b/src/strings-test/prefixes.scala
@@ -1,0 +1,57 @@
+/*
+   ╔═══════════════════════════════════════════════════════════════════════════════════════════════════════════╗
+   ║ Fury, version 0.5.0. Copyright 2018-19 Jon Pretty, Propensive Ltd.                                        ║
+   ║                                                                                                           ║
+   ║ The primary distribution site is: https://propensive.com/                                                 ║
+   ║                                                                                                           ║
+   ║ Licensed under  the Apache License,  Version 2.0 (the  "License"); you  may not use  this file  except in ║
+   ║ compliance with the License. You may obtain a copy of the License at                                      ║
+   ║                                                                                                           ║
+   ║     http://www.apache.org/licenses/LICENSE-2.0                                                            ║
+   ║                                                                                                           ║
+   ║ Unless required  by applicable law  or agreed to in  writing, software  distributed under the  License is ║
+   ║ distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. ║
+   ║ See the License for the specific language governing permissions and limitations under the License.        ║
+   ╚═══════════════════════════════════════════════════════════════════════════════════════════════════════════╝
+*/
+
+package fury
+
+import fury.strings._
+
+import probably._
+
+import scala.collection.JavaConverters._
+
+import java.util.Random
+
+import scala.language.implicitConversions
+
+object StringsTests extends TestApp {
+
+  val distinctFirstCharacters = Set("abc", "def", "ghi", "jkl")
+  val duplicateFirstCharacter = distinctFirstCharacters + "afz"
+  val randomDoubles = new Random(0).doubles.iterator.asScala.map(_.toString).take(1000000).to[Set]
+
+  override def tests(): Unit = {
+    test("distinct trigraphs need just a single character") {
+      Compare.uniquePrefixes(distinctFirstCharacters)
+    }.assert(_ == Set("a", "d", "g", "j"))
+
+    test("one duplicate first character requires two characters") {
+      Compare.uniquePrefixes(duplicateFirstCharacter)
+    }.assert(_ == Set("ab", "af", "de", "gh", "jk"))
+
+    test("different length strings") {
+      Compare.uniquePrefixes(Set("one", "two", "three", "four"))
+    }.assert(_.size == 4)
+
+    test("large set all distinct") {
+      Compare.uniquePrefixes(randomDoubles)
+    }.assert(_.size == randomDoubles.size)
+    
+    test("large set not longer than necessary") {
+      Compare.uniquePrefixes(randomDoubles).map(_.dropRight(1))
+    }.assert(_.size < randomDoubles.size)
+  }
+}

--- a/src/strings-test/prefixes.scala
+++ b/src/strings-test/prefixes.scala
@@ -35,23 +35,31 @@ object StringsTests extends TestApp {
 
   override def tests(): Unit = {
     test("distinct trigraphs need just a single character") {
-      Compare.uniquePrefixes(distinctFirstCharacters)
-    }.assert(_ == Set("a", "d", "g", "j"))
+      Compare.uniquePrefixLength(distinctFirstCharacters)
+    }.assert(_ == 1)
 
     test("one duplicate first character requires two characters") {
-      Compare.uniquePrefixes(duplicateFirstCharacter)
-    }.assert(_ == Set("ab", "af", "de", "gh", "jk"))
+      Compare.uniquePrefixLength(duplicateFirstCharacter)
+    }.assert(_ == 2)
 
     test("different length strings") {
-      Compare.uniquePrefixes(Set("one", "two", "three", "four"))
+      val numbers = Set("one", "two", "three", "four")
+      val length = Compare.uniquePrefixLength(numbers)
+      numbers.map(_.take(length))
     }.assert(_.size == 4)
 
     test("large set all distinct") {
-      Compare.uniquePrefixes(randomDoubles)
+      val length = Compare.uniquePrefixLength(randomDoubles)
+      randomDoubles.map(_.take(length))
     }.assert(_.size == randomDoubles.size)
     
     test("large set not longer than necessary") {
-      Compare.uniquePrefixes(randomDoubles).map(_.dropRight(1))
+      val length = Compare.uniquePrefixLength(randomDoubles)
+      randomDoubles.map(_.take(length - 1))
     }.assert(_.size < randomDoubles.size)
+    
+    test("does not fail on empty input") {
+      Compare.uniquePrefixLength(Set())
+    }.assert(_ == 0)
   }
 }

--- a/src/strings/strings.scala
+++ b/src/strings/strings.scala
@@ -110,10 +110,11 @@ object Compare {
     dist(n)
   }
 
-  def uniquePrefixes(xs: Set[String]): Set[String] = {
+  def uniquePrefixLength(xs: Set[String]): Int = {
     val array = xs.to[Array]
     scala.util.Sorting.quickSort(array)
-    val prefixSize = array.indices.init.foldLeft(-1) { (base, idx) =>
+    if(array.isEmpty) 0
+    else array.indices.init.foldLeft(-1) { (base, idx) =>
       val a = array(idx)
       val b = array(idx + 1)
       val size = a.length.min(b.length)
@@ -123,7 +124,5 @@ object Compare {
         case n  => n + 1
       })
     }
-
-    array.map(_.take(prefixSize)).to[Set]
   }
 }

--- a/src/strings/strings.scala
+++ b/src/strings/strings.scala
@@ -90,7 +90,6 @@ object StringShow {
 trait StringShow[-T] { def show(value: T): String }
 
 object Compare {
-
   def editDistance(from: String, to: String) = {
     val m       = from.length
     val n       = to.length
@@ -109,5 +108,22 @@ object Compare {
       for (j <- 0 to n) oldDist(j) = dist(j)
     }
     dist(n)
+  }
+
+  def uniquePrefixes(xs: Set[String]): Set[String] = {
+    val array = xs.to[Array]
+    scala.util.Sorting.quickSort(array)
+    val prefixSize = array.indices.init.foldLeft(-1) { (base, idx) =>
+      val a = array(idx)
+      val b = array(idx + 1)
+      val size = a.length.min(b.length)
+      
+      base.max(((0 until size).indexWhere { i => a(i) != b(i) }) match {
+        case -1 => size + 1
+        case n  => n + 1
+      })
+    }
+
+    array.map(_.take(prefixSize)).to[Set]
   }
 }

--- a/test/passing/app-inputs/script
+++ b/test/passing/app-inputs/script
@@ -5,6 +5,18 @@ fury module update -C scala-lang.org:scala-compiler:2.12.8
 fury binary add -b org.scala-lang:scala-compiler:2.12.8
 fury project add -n example
 fury module add -n app -c scala/compiler -t application -M Print
+fury permission require -C java.util.PropertyPermission -T scala.maven.version.number -A read
+fury permission require -C java.util.PropertyPermission -T scala.version.number -A read
+fury permission require -C java.util.PropertyPermission -T scala.time -A read
+fury permission require -C java.util.PropertyPermission -T scala.copyright.string -A read
+fury permission require -C java.util.PropertyPermission -T test.property -A read
+fury permission require -C java.lang.RuntimePermission -T getenv.TEST1
+fury permission grant -P 0
+fury permission grant -P 1
+fury permission grant -P 4
+fury permission grant -P 7
+fury permission grant -P c
+fury permission grant -P d
 fury env add -e TEST1='Test message'
 fury property add -D test.property=something
 mkdir -p src/app

--- a/test/passing/fat-jar/script
+++ b/test/passing/fat-jar/script
@@ -5,6 +5,18 @@ fury module update -C scala-lang.org:scala-compiler:2.12.8
 fury binary add -b org.scala-lang:scala-compiler:2.12.8
 fury project add -n bar
 fury module add -n app -c scala/compiler -t application -M HelloWorld
+fury permission require -C java.util.PropertyPermission -T scala.maven.version.number -A read
+fury permission require -C java.util.PropertyPermission -T scala.version.number -A read
+fury permission require -C java.util.PropertyPermission -T scala.time -A read
+fury permission require -C java.util.PropertyPermission -T scala.copyright.string -A read
+fury permission require -C java.util.PropertyPermission -T test.property -A read
+fury permission require -C java.lang.RuntimePermission -T getenv.TEST1
+fury permission grant -P 0
+fury permission grant -P 1
+fury permission grant -P 4
+fury permission grant -P 7
+fury permission grant -P c
+fury permission grant -P d
 mkdir -p src/app
 fury source add -d src/app
 echo 'object HelloWorld extends App { println("Hello World") }' > src/app/hw.scala

--- a/test/passing/hello-world/script
+++ b/test/passing/hello-world/script
@@ -5,6 +5,20 @@ fury module update -C scala-lang.org:scala-compiler:2.12.8
 fury binary add -b org.scala-lang:scala-compiler:2.12.8
 fury project add -n hello-world
 fury module add -n app -c scala/compiler -t application -M HelloWorld
+fury permission require -C java.util.PropertyPermission -T scala.maven.version.number -A read
+fury permission require -C java.util.PropertyPermission -T scala.version.number -A read
+fury permission require -C java.util.PropertyPermission -T scala.time -A read
+fury permission require -C java.util.PropertyPermission -T scala.copyright.string -A read
+fury permission require -C java.util.PropertyPermission -T test.property -A read
+fury permission require -C java.lang.RuntimePermission -T getenv.TEST1
+fury permission grant -P 0
+fury permission grant -P 1
+fury permission grant -P 4
+fury permission grant -P 7
+fury permission grant -P c
+fury permission grant -P d
+fury permission require -C java.io.FilePermission -T '.content' -A write
+fury permission grant -P b
 fury source add -d src
 mkdir -p src
 echo 'object HelloWorld extends App { new java.io.PrintWriter(".content") { println("Hello World\n"); close() } }' > src/hw.scala

--- a/test/passing/hello-world2/script
+++ b/test/passing/hello-world2/script
@@ -5,6 +5,20 @@ fury module update -C scala-lang.org:scala-compiler:2.12.8
 fury binary add -b org.scala-lang:scala-compiler:2.12.8
 fury project add -n hello-world2
 fury module add -n app -c scala/compiler -t application -M HelloWorld
+fury permission require -C java.util.PropertyPermission -T scala.maven.version.number -A read
+fury permission require -C java.util.PropertyPermission -T scala.version.number -A read
+fury permission require -C java.util.PropertyPermission -T scala.time -A read
+fury permission require -C java.util.PropertyPermission -T scala.copyright.string -A read
+fury permission require -C java.util.PropertyPermission -T test.property -A read
+fury permission require -C java.lang.RuntimePermission -T getenv.TEST1
+fury permission grant -P 0
+fury permission grant -P 1
+fury permission grant -P 4
+fury permission grant -P 7
+fury permission grant -P c
+fury permission grant -P d
+fury permission require -C java.io.FilePermission -T '.content' -A write
+fury permission grant -P b
 fury source add -d src
 mkdir -p src
 echo 'object HelloWorld extends App { new java.io.PrintWriter(".content") { write("Hello World 2\n"); close() } }' > src/hw.scala

--- a/test/passing/save-jar/script
+++ b/test/passing/save-jar/script
@@ -9,6 +9,20 @@ mkdir -p src/lib
 fury source add -d src/lib
 echo 'object Constants { val text = "Hello World\n" }' > src/lib/constants.scala
 fury module add -n app -c scala/compiler -t application -M HelloWorld
+fury permission require -C java.util.PropertyPermission -T scala.maven.version.number -A read
+fury permission require -C java.util.PropertyPermission -T scala.version.number -A read
+fury permission require -C java.util.PropertyPermission -T scala.time -A read
+fury permission require -C java.util.PropertyPermission -T scala.copyright.string -A read
+fury permission require -C java.util.PropertyPermission -T test.property -A read
+fury permission require -C java.lang.RuntimePermission -T getenv.TEST1
+fury permission grant -P 0
+fury permission grant -P 1
+fury permission grant -P 4
+fury permission grant -P 7
+fury permission grant -P c
+fury permission grant -P d
+fury permission require -C java.io.FilePermission -T '.content' -A write
+fury permission grant -P b
 fury dependency add -l lib
 mkdir -p src/app
 fury source add -d src/app


### PR DESCRIPTION
This is the start of support for a security layer for Fury, and adds support for requiring permissions to run certain application modules as part of their definition.

The commands, `fury permission require` and `fury permission obviate` can be used to add and remove the permissions necessary for each application module to run. This does not grant an application module those rights; it merely specifies what they are. A separate command, `fury permission grant` is provided to actually grant the permissions in the current environment (i.e. the current installation of Fury on a computer).

I'm experimenting with the best way to grant permissions, and the best ways to grant a permission to an application module, without needing to repeatedly re-grant it whenever something changes.

To do:
- [ ] `--all` flag on `fury permission grant` command to grant all permissions for a particular module
- [ ] Permission revocation
- [ ] Checking of permissions before launching compilation (currently they're checked only by the security manager)
- [ ] Option to grant a permission on the local machine at the same time as adding it to a module
- [ ] Provision of an optional "reason" field to explain why a permission is required