### PR TITLE
Revert "Updated the version of Coursier to 2.0.0-RC3-2 (#452)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ bootstrap/bin:
 
 jmh_jars=org.openjdk.jmh:jmh-core:1.21 org.openjdk.jmh:jmh-generator-bytecode:1.21 org.openjdk.jmh:jmh-generator-reflection:1.21 org.openjdk.jmh:jmh-generator-asm:1.21
 bsp_jars=org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.6.0 ch.epfl.scala:bsp4j:2.0.0-M4 ch.epfl.scala:bloop-launcher_2.12:$(BLOOPVERSION)
-coursier_jars=io.get-coursier:coursier_2.12:2.0.0-RC3-2
+coursier_jars=io.get-coursier:coursier_2.12:1.1.0-M14-4
 external_jars=$(jmh_jars) $(bsp_jars) $(coursier_jars)
 
 dependency-jars: dist/bundle/bin/coursier dist/bundle/lib
@@ -154,7 +154,7 @@ dist/bundle/bin/fury: $(foreach D, $(BINDEPS), dist/bundle/bin/$(D)) $(foreach D
 	chmod +x $@
 
 dist/bundle/bin/coursier: dist/bundle/bin/.dir
-	curl -s -L -o $@ https://github.com/coursier/coursier/releases/download/v2.0.0-RC3-2/coursier
+	curl -s -L -o $@ https://github.com/coursier/coursier/releases/download/v1.1.0-M14-4/coursier
 	chmod +x $@
 
 dist/bundle/bin/ng.c: bootstrap/ng/.dir

--- a/layer.fury
+++ b/layer.fury
@@ -77,10 +77,10 @@ schemas	default	id	default
 								group	ch.epfl.scala
 								artifact	bsp4j
 								version	2.0.0-M4
-							io.get-coursier:coursier_2.12:2.0.0-RC3-2	binRepo	central
+							io.get-coursier:coursier_2.12:1.1.0-M14-4	binRepo	central
 								group	io.get-coursier
 								artifact	coursier_2.12
-								version	2.0.0-RC3-2
+								version	1.1.0-M14-4
 							org.openjdk.jmh:jmh-core:1.21	binRepo	central
 								group	org.openjdk.jmh
 								artifact	jmh-core

--- a/src/core/manifest.scala
+++ b/src/core/manifest.scala
@@ -20,7 +20,6 @@ package fury.core
 import fury.strings._
 import java.util.jar.{Attributes, Manifest => JavaManifest}
 import Attributes.Name._
-import scala.collection.immutable.SortedSet
 
 object Manifest {
   def apply(classpath: Set[String], mainClass: Option[String]): JavaManifest = {
@@ -28,7 +27,7 @@ object Manifest {
     val mainAttributes = result.getMainAttributes
     mainAttributes.put(MANIFEST_VERSION, "1.0")
     mainClass.foreach(mainAttributes.put(MAIN_CLASS, _))
-    mainAttributes.put(CLASS_PATH, classpath.to[SortedSet].join(" "))
+    mainAttributes.put(CLASS_PATH, classpath.join(" "))
     mainAttributes.putValue("Created-By", str"Fury ${Version.current}")
     
     result

--- a/test/passing/fat-jar/check
+++ b/test/passing/fat-jar/check
@@ -23,8 +23,8 @@ HelloWorld.class
 Hello World
 0
 Manifest-Version: 1.0
-Class-Path: scala-compiler-2.12.8.jar scala-library-2.12.8.jar scala-r
- eflect-2.12.8.jar scala-xml_2.12-1.0.6.jar
+Class-Path: scala-library-2.12.8.jar scala-compiler-2.12.8.jar scala-x
+ ml_2.12-1.0.6.jar scala-reflect-2.12.8.jar
 Created-By: Fury 0.5.0
 Main-Class: HelloWorld
 

--- a/test/passing/save-jar/check
+++ b/test/passing/save-jar/check
@@ -23,8 +23,8 @@ HelloWorld$.class
 HelloWorld.class
 META-INF/MANIFEST.MF
 Manifest-Version: 1.0
-Class-Path: scala-compiler-2.12.8.jar scala-library-2.12.8.jar scala-r
- eflect-2.12.8.jar scala-xml_2.12-1.0.6.jar
+Class-Path: scala-library-2.12.8.jar scala-compiler-2.12.8.jar scala-x
+ ml_2.12-1.0.6.jar scala-reflect-2.12.8.jar
 Created-By: Fury 0.5.0
 Main-Class: HelloWorld
 


### PR DESCRIPTION
The reason is that Bloop 1.3.2 depends on Coursier 1.1.0-M14-4, and Fury cannot manage conflicts between binary dependencies yet.
This reverts commit 73d405d7f58af9aaf7299eceff27fbccbf3a3766.