### PR TITLE
Synchronized the connection borrowing completely

### DIFF
--- a/src/utils/pool.scala
+++ b/src/utils/pool.scala
@@ -53,15 +53,16 @@ abstract class Pool[K, T](timeout: Long)(implicit ec: ExecutionContext) {
   }
 
   def borrow[S](key: K)(action: T => S): S = {
-    val value: T = synchronized {
-      pool.get(key).filter(!isBad(_)).fold(createOrRecycle(key)) { value =>
+    val result: S = synchronized {
+      val value: T = pool.get(key).filter(!isBad(_)).fold(createOrRecycle(key)) { value =>
         pool -= key
         value
       }
-    }
 
-    val result: S = action(value)
-    synchronized { pool(key) = value }
+      val result: S = action(value)
+      pool(key) = value
+      result
+    }
 
     result
   }


### PR DESCRIPTION
The current version of the connection pool places the code that acquires and releases connections into two separate synchronized blocks, while the code that actually uses the connection is not synchronized at all. 

This can (and often does) lead to a situation in which a thread requests the connection for a certain directory, while an existing connection has been borrowed by another thread. Since the borrowed connection is not present in the pool, a new one is created.

After both threads release their connections, only one of them gets stored in the pool; the other one keeps running indefinitely, with no handle to use it and no way to dispose of it.