### PR TITLE
Eliminated the name collision of test suites.

### DIFF
--- a/layer.fury
+++ b/layer.fury
@@ -463,7 +463,7 @@ schemas	default	id	default
 						policy	
 					test-core	id	test-core
 						kind	Application
-						main	Some	fury.Tests
+						main	Some	fury.CoreTests
 						plugin	None
 						manifest	
 						compiler	projectId	scala
@@ -488,7 +488,7 @@ schemas	default	id	default
 						policy	
 					test-ogdl	id	test-ogdl
 						kind	Application
-						main	Some	fury.Tests
+						main	Some	fury.OgdlTests
 						plugin	None
 						manifest	
 						compiler	projectId	scala

--- a/src/core-test/tests.scala
+++ b/src/core-test/tests.scala
@@ -18,7 +18,7 @@ package fury
 
 import probably.TestApp
 
-object Tests {
+object CoreTests {
   private val testSuites = List[TestApp](
       DirectedGraphTest,
       LayerRepositoryTest,

--- a/src/ogdl-test/tests.scala
+++ b/src/ogdl-test/tests.scala
@@ -19,7 +19,7 @@ package fury
 import fury.ogdl.{OgdlParserTest, OgdlSerializerTest}
 import probably.TestApp
 
-object Tests {
+object OgdlTests {
   private val testSuites = List[TestApp](
       OgdlParserTest,
       OgdlSerializerTest


### PR DESCRIPTION
I'm convinced this is the real reason behind seemingly missing or duplicated output in the test phase of the cloud build. Neither of those problems should ever appear in this pull request.

This pull request resolves the issue #505.