### PR TITLE
Better installation script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ opt:
 	mkdir -p opt
 
 opt/fury-$(FURYSTABLE).tar.gz: opt
-	curl -C - -s -o $@ "https://storage.googleapis.com/revivalist/downloads/fury.build/fury-$(FURYSTABLE).sh"
+	curl -s -o $@ "https://storage.googleapis.com/revivalist/downloads/fury.build/fury-$(FURYSTABLE).sh"
 
 $(FURYLOCAL): opt/fury-$(FURYSTABLE).tar.gz
 	sh opt/fury-$(FURYSTABLE).tar.gz opt/fury-$(FURYSTABLE)

--- a/etc/fury
+++ b/etc/fury
@@ -73,7 +73,7 @@ killFury() {
 forceKill() {
   bash <<END
     printf 'Killing everything that looks like fury or bloop...'
-    pkill --signal SIGKILL -f '(fury)|(bloop)'
+    pkill -9 -f '(fury)|(bloop)'
     pgrep -f '(fury)|(bloop)' && printf '\nProcesses with these PIDs have survived.\n' || printf 'done\n'
 END
 }


### PR DESCRIPTION
The script should now work on Linux and Mac OS. 

When editing the shell configuration files, it will try to find a file that already exists. If there are none, the configuration will be written in such a way that it is applied to each new terminal, without requiring the user to log out first.

Feedback from users of Zsh, Fish and Mac OS is especially needed.

This pull request fixes issues #439, #530 and #531.