### PR TITLE
Refactored the domain object for the compilation results.

### DIFF
--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -307,7 +307,7 @@ object BuildCli {
               for{
                 compileResult  <- completed
                 compileSuccess <- compileResult.asTry
-                _              <- compilation.saveJars(io, module.ref(project), compileSuccess.outputDirectories,
+                _              <- compilation.saveJars(io, module.ref(project), compileSuccess.classDirectories,
                   dir in layout.pwd, layout, fatJar)
               } yield compileSuccess
             }


### PR DESCRIPTION
These changes will make it easier to deduplicate multiple compilations that can be requested by a BSP client, and merge the results of those compilations into a single response.