### PR TITLE
Daemonize all the things

### DIFF
--- a/src/build/rebuild.scala
+++ b/src/build/rebuild.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import _root_.io.methvin.better.files.RecursiveFileMonitor
 import better.files.File
 import fury.io.Path
+import fury.utils.Threads
 
 import scala.concurrent.ExecutionContext
 
@@ -80,6 +81,6 @@ class SourceWatcher(sources: Set[Path]){
 }
 
 object SourceWatcher{
-  val executor = java.util.concurrent.Executors.newCachedThreadPool()
+  val executor = java.util.concurrent.Executors.newCachedThreadPool(Threads.factory("file-watcher", daemon = true))
   val ec: ExecutionContext = ExecutionContext.fromExecutor(executor, throw _)
 }

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -218,7 +218,7 @@ object BspConnectionManager {
     private val handles: scala.collection.mutable.Map[Handle, PrintWriter] = TrieMap()
 
     private val ec: ExecutionContext =
-      ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor(), throw _)
+      ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor(Threads.factory("handle-handler", daemon = true)), throw _)
 
     def handle(handle: Handle, sink: PrintWriter): Unit = handles(handle) = sink
 
@@ -290,7 +290,7 @@ object BspConnectionManager {
 }
 
 object Compilation {
-  private val compilationThreadPool = Executors.newCachedThreadPool()
+  private val compilationThreadPool = Executors.newCachedThreadPool(Threads.factory("bsp-launcher", daemon = true))
 
   //FIXME
   var receiverClient: Option[BuildClient] = None

--- a/src/utils/thread.scala
+++ b/src/utils/thread.scala
@@ -1,0 +1,20 @@
+package fury.utils
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{Executors, ThreadFactory}
+
+object Threads {
+
+  private val baseFactory = Executors.defaultThreadFactory()
+
+  def factory(prefix: String, daemon: Boolean = false): ThreadFactory = new ThreadFactory {
+    private val threadCounter = new AtomicInteger(0)
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = baseFactory.newThread(runnable)
+      thread.setName(s"$prefix-${threadCounter.getAndIncrement}")
+      thread.setDaemon(daemon)
+      thread
+    }
+  }
+
+}


### PR DESCRIPTION
This makes the stop command functional.
After a continuous rebuild had been launched, the stop command doesn't work, but the kill command works even without the force switch.

Both commands leave the Bloop server in place, terminating just the Nailgun process.

