### PR TITLE
Print out the work directories for BSP connections.

### DIFF
--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -144,9 +144,11 @@ object BuildCli {
     val used = magnitude(runtime.totalMemory - runtime.freeMemory)
     val max = magnitude(runtime.maxMemory)
 
-    str"""    CPUs: ${runtime.availableProcessors}
+    (str"""    CPUs: ${runtime.availableProcessors}
          |  Memory: ${used}B used, ${free}B free, ${total}B total, ${max}B max
-         |     BSP: ${Compilation.bspPool.size} connections""".stripMargin
+         |     BSP: ${Compilation.bspPool.keySet.size} connections""" + "\n" +
+      Compilation.bspPool.keySet.map{ path => str"            ${path}" }.mkString("\n")
+      ).stripMargin
   }
 
   private val formatter: java.text.DecimalFormat = new java.text.DecimalFormat("0.00")

--- a/src/core-test/testpool.scala
+++ b/src/core-test/testpool.scala
@@ -46,7 +46,7 @@ object PoolTest extends TestApp {
       dummyPool.syncBorrow("a/b/c")(void)
       dummyPool.syncBorrow("a/b/x")(void)
       dummyPool.syncBorrow("a/b/c")(void)
-      dummyPool.size
+      dummyPool.keySet.size
     }.assert(_ == 2)
 
     test("support concurrent requests") {

--- a/src/utils/pool.scala
+++ b/src/utils/pool.scala
@@ -16,7 +16,8 @@
 */
 package fury.utils
 
-import scala.collection.mutable._
+import scala.collection.mutable.Map
+import scala.collection.Set
 import scala.concurrent._
 import scala.util._
 
@@ -28,7 +29,7 @@ abstract class Pool[K, T <: AnyRef](timeout: Long)(implicit ec: ExecutionContext
 
   private[this] val pool: Map[K, Future[T]] = scala.collection.concurrent.TrieMap()
   
-  def size: Int = pool.size
+  def keySet: Set[K] = pool.keySet
 
   private[this] final def createOrRecycle(key: K): Future[T] = {
     val result = pool.get(key) match {


### PR DESCRIPTION
```
$ fury about
     _____ 
    / ___/__ __ ____ __ __
   / __/ / // // ._// // /
  /_/    \_._//_/  _\_. /
                   \___/

Fury build tool for Scala, version 0.6.7.
This software is provided under the Apache 2.0 License.
Fury depends on Bloop, Coursier, Git and Nailgun.
© Copyright 2018-19 Jon Pretty, Propensive OÜ.

See the Fury website at https://fury.build/, or follow @propensive on Twitter
for more information.

    CPUs: 8
  Memory: 29.0MB used, 325.0MB free, 354.0MB total, 5.2GB max
     BSP: 3 connections
            ~/devel/fury/test/tmp/app-args
            ~/devel/fury/test/tmp/app-inputs
            ~/devel/fury/test/tmp/build-zio

[18320] started 42.38s ago
[18533] started 0.00s ago

For help on using Fury, run: fury help
```