### PR TITLE
Improved output of the build-zio test.

### DIFF
--- a/test/passing/build-zio/check
+++ b/test/passing/build-zio/check
@@ -1,1 +1,34 @@
+Checking out * from repository scala
+Checking out core/jvm/src/main/java from repository zio
+Checking out jvm/src/main/java from repository portable-scala-reflect
+Checking out jvm/src/main/scala from repository portable-scala-reflect
+Checking out {core/jvm/src/main/java, core/jvm/src/main/scala, core/jvm/src/main/scala-2.12, core/shared/src/main/scala, core/shared/src/main/scala-2.12+} from repository zio
+Checking out {stacktracer/jvm/src/main/scala, stacktracer/shared/src/main/scala} from repository zio
+Checking out {streams/jvm/src/main/scala, streams/shared/src/main/scala} from repository zio
+Checking out {test/jvm/src/main/scala, test/jvm/src/test/scala, test/shared/src/main/scala, test/shared/src/test/scala} from repository zio
+Cloning repository at https://github.com/portable-scala/portable-scala-reflect.git
+Cloning repository at https://github.com/propensive/.scala.git
+Cloning repository at https://github.com/zio/zio.git
+Resolving com.github.ghik:silencer-lib_2.12:1.4.2
+Resolving org.openjdk.jcstress:jcstress-core:0.4
+Resolving org.specs2:specs2-core_2.12:4.7.1
+Resolving org.specs2:specs2-matcher-extra_2.12:4.7.1
+Resolving org.specs2:specs2-scalacheck_2.12:4.7.1
+Starting compilation of module portable-scala-reflect/core
+Starting compilation of module portable-scala-reflect/psr-java
+Starting compilation of module zio/core
+Starting compilation of module zio/core-java
+Starting compilation of module zio/stacktracer
+Starting compilation of module zio/streams
+Starting compilation of module zio/test
+Successfully compiled module portable-scala-reflect/core
+Successfully compiled module portable-scala-reflect/psr-java
+Successfully compiled module zio/core
+Successfully compiled module zio/core-java
+Successfully compiled module zio/stacktracer
+Successfully compiled module zio/streams
+Successfully compiled module zio/test
+there were two feature warnings; re-run with -feature for details
+0
+Checking out {core-tests/jvm/src/test, core-tests/shared/src/test} from repository zio
 0

--- a/test/passing/build-zio/script
+++ b/test/passing/build-zio/script
@@ -1,4 +1,5 @@
 fury project select -p zio
-fury module select -m core-tests
-fury build compile --output quiet > /dev/null
+fury build compile -m test --output linear | sort
+echo $?
+fury build compile -m core-tests --output quiet
 echo $?


### PR DESCRIPTION
The output of the compile phase will be useful to locate the causes of possible compile errors. The output lines had to be sorted, because the project contains modules that don't depend on each other and, therefore, may be built in any order.