### PR TITLE
Included command line arguments into the task listing.

### DIFF
--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -155,7 +155,7 @@ object BuildCli {
   def since(start: Long): String = str"${formatter.format((System.currentTimeMillis - start)/1000.0)}s"
 
   def builds: String = Lifecycle.sessions.map { session =>
-    str"[${session.pid}] started ${since(session.started)} ago"
+    str"[${session.pid}] started ${since(session.started)} ago: ${session.cli.args.args.mkString(" ")}"
   }.mkString("\n")
 
   def about(cli: Cli[CliParam[_]]): Try[ExitStatus] =

--- a/src/frontend/main.scala
+++ b/src/frontend/main.scala
@@ -86,8 +86,9 @@ object Main {
       env: Environment
     ) =
     exit {
-      Lifecycle.trackThread(args.head.toInt) {
-        val cli = Cli(out, ParamMap(args.tail: _*), None, Nil, env, args.head.toInt)
+      val pid = args.head.toInt
+      val cli = Cli(out, ParamMap(args.tail: _*), command = None, optCompletions = Nil, env, pid)
+      Lifecycle.trackThread(cli) {
         val end = invoke(cli).code
         out.flush()
         err.flush()


### PR DESCRIPTION
```
$ fury about
     _____ 
    / ___/__ __ ____ __ __
   / __/ / // // ._// // /
  /_/    \_._//_/  _\_. /
                   \___/

Fury build tool for Scala, version 0.6.7.
This software is provided under the Apache 2.0 License.
Fury depends on Bloop, Coursier, Git and Nailgun.
© Copyright 2018-19 Jon Pretty, Propensive OÜ.

See the Fury website at https://fury.build/, or follow @propensive on Twitter
for more information.

    CPUs: 8
  Memory: 67.5MB used, 340.5MB free, 408.0MB total, 5.2GB max
     BSP: 3 connections
            ~/devel/fury/test/tmp/app-args
            ~/devel/fury/test/tmp/app-inputs
            ~/devel/fury/test/tmp/build-zio

[32516] started 31.17s ago: build compile -m test --output linear
[400] started 0.00s ago: about
```