### PR TITLE
Append to PATH instead of prepending

### DIFF
--- a/etc/bashrc
+++ b/etc/bashrc
@@ -1,4 +1,4 @@
-export PATH=$FURYHOME/bin:$PATH
+export PATH=$PATH:$FURYHOME/bin
 
 # FIXME: Need to include bash completions
 

--- a/etc/fishrc
+++ b/etc/fishrc
@@ -1,5 +1,5 @@
 if not contains $FURYHOME/bin $fish_user_paths
-  set -Ux fish_user_paths $FURYHOME/bin \$fish_user_paths
+  set -Ux fish_user_paths $fish_user_paths\ $FURYHOME/bin
 end
 
 # FIXME: Need to include fish completions

--- a/etc/zshrc
+++ b/etc/zshrc
@@ -1,4 +1,4 @@
-export PATH=$FURYHOME/bin:$PATH
+export PATH=$PATH:$FURYHOME/bin
 export fpath=($FURYHOME/etc/completion/zsh $fpath)
 autoload -U +X compinit && compinit
 


### PR DESCRIPTION
Reasoning: fury-installed bloop/coursier/whatnot should probably not cover up the programs already available on the PATH.