### PR TITLE
Add module param to binary add command

### DIFF
--- a/src/module/module.scala
+++ b/src/module/module.scala
@@ -51,7 +51,7 @@ object ModuleCli {
     cli          <- cli.hint(ProjectArg, schema.map(_.projects).getOrElse(Nil))
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
-    cli         <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
+    cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
   } yield Context(cli, layout, config, layer, schema, optProject)
 
   def select(ctx: Context): Try[ExitStatus] = {

--- a/src/module/module.scala
+++ b/src/module/module.scala
@@ -51,6 +51,7 @@ object ModuleCli {
     cli          <- cli.hint(ProjectArg, schema.map(_.projects).getOrElse(Nil))
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
+    cli         <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
   } yield Context(cli, layout, config, layer, schema, optProject)
 
   def select(ctx: Context): Try[ExitStatus] = {
@@ -268,8 +269,7 @@ object BinaryCli {
 
   def context(cli: Cli[CliParam[_]]) = for {
     ctx         <- ModuleCli.context(cli)
-    cli         <- cli.hint(ModuleArg, ctx.optProject.to[List].flatMap(_.modules))
-    optModuleId <- ~cli.peek(ModuleArg).orElse(ctx.optProject.flatMap(_.main))
+    optModuleId <- ~ctx.cli.peek(ModuleArg).orElse(ctx.optProject.flatMap(_.main))
 
     optModule   <- Success { for {
                       project  <- ctx.optProject
@@ -357,8 +357,7 @@ object ParamCli {
   def context(cli: Cli[CliParam[_]]) =
     for {
       ctx         <- ModuleCli.context(cli)
-      cli         <- cli.hint(ModuleArg, ctx.optProject.to[List].flatMap(_.modules))
-      optModuleId <- ~cli.peek(ModuleArg).orElse(ctx.optProject.flatMap(_.main))
+      optModuleId <- ~ctx.cli.peek(ModuleArg).orElse(ctx.optProject.flatMap(_.main))
 
       optModule   <- Success { for {
                        project  <- ctx.optProject

--- a/src/module/module.scala
+++ b/src/module/module.scala
@@ -277,7 +277,7 @@ object BinaryCli {
                       module   <- project.modules.findBy(moduleId).toOption
                     } yield module }
 
-  } yield BinariesCtx(ctx, optModule)
+  } yield BinariesCtx(ctx.copy(cli = cli), optModule)
 
   def list(ctx: BinariesCtx): Try[ExitStatus] = {
     import ctx._, moduleCtx._
@@ -366,7 +366,7 @@ object ParamCli {
                        module   <- project.modules.findBy(moduleId).toOption
                      } yield module }
 
-    } yield ParamCtx(ctx, optModule)
+    } yield ParamCtx(ctx.copy(cli = cli), optModule)
 
   def list(ctx: ParamCtx): Try[ExitStatus] = {
     import ctx._, moduleCtx._

--- a/src/module/module.scala
+++ b/src/module/module.scala
@@ -51,7 +51,6 @@ object ModuleCli {
     cli          <- cli.hint(ProjectArg, schema.map(_.projects).getOrElse(Nil))
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
-    cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
   } yield Context(cli, layout, config, layer, schema, optProject)
 
   def select(ctx: Context): Try[ExitStatus] = {
@@ -269,7 +268,8 @@ object BinaryCli {
 
   def context(cli: Cli[CliParam[_]]) = for {
     ctx         <- ModuleCli.context(cli)
-    optModuleId <- ~ctx.cli.peek(ModuleArg).orElse(ctx.optProject.flatMap(_.main))
+    cli         <- cli.hint(ModuleArg, ctx.optProject.to[List].flatMap(_.modules))
+    optModuleId <- ~cli.peek(ModuleArg).orElse(ctx.optProject.flatMap(_.main))
 
     optModule   <- Success { for {
                       project  <- ctx.optProject
@@ -357,7 +357,8 @@ object ParamCli {
   def context(cli: Cli[CliParam[_]]) =
     for {
       ctx         <- ModuleCli.context(cli)
-      optModuleId <- ~ctx.cli.peek(ModuleArg).orElse(ctx.optProject.flatMap(_.main))
+      cli         <- cli.hint(ModuleArg, ctx.optProject.to[List].flatMap(_.modules))
+      optModuleId <- ~cli.peek(ModuleArg).orElse(ctx.optProject.flatMap(_.main))
 
       optModule   <- Success { for {
                        project  <- ctx.optProject


### PR DESCRIPTION
The -m option was being supplied in a cli that was not being used neither in the BinariesCtx nor the ParamCtx. Moved it to the ModuleCli.context. 

This should fix #260 for binaries and also for params.