### PR TITLE
Improve binary resolution in "binary remove"

### DIFF
--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -63,6 +63,23 @@ object Binary {
   private val compilerVersionCache: HashMap[Binary, Try[String]] = HashMap()
 
   val Jmh = Binary(BinRepoId.Central, "org.openjdk.jmh", "jmh-core", "1.21")
+
+  /**
+    * Filters a set of Binaries by id, allowing full and partial matches:
+    *  - group:artifact:version
+    *  - artifact:version
+    *  - group:artifact
+    *  - artifact
+    */
+  def filterByPartialId(binaries: SortedSet[Binary], id: String): List[Binary] =
+    binaries.filter(bin => id match {
+      case r"([\.\-_a-zA-Z0-9]*)\:([\.\-_a-zA-Z0-9]*)\:([\.\-\+_a-zA-Z0-9]*)" =>
+        id == bin.spec
+      case r"([\.\-_a-zA-Z0-9]*)\:([\.\-\+_a-zA-Z0-9]*)" =>
+        id == str"${bin.group}:${bin.artifact}" || id == str"${bin.artifact}:${bin.version}"
+      case _ =>
+        id == bin.artifact
+    }).toList
 }
 
 case class Binary(binRepo: BinRepoId, group: String, artifact: String, version: String) {

--- a/src/frontend/recovery.scala
+++ b/src/frontend/recovery.scala
@@ -120,6 +120,10 @@ You can grant these permissions with,
           cli.abort(msg"Fury is already initialized in this directory. Use --force to override.")
         case CyclesInDependencies(refs) =>
           cli.abort(msg"There are dependency cycles containing : [${refs.mkString}]")
+        case UnspecifiedBinary(Nil) =>
+          cli.abort(msg"Binary not found.")
+        case UnspecifiedBinary(possibleBinaries) =>
+          cli.abort(msg"Unable to identify target binary: ${"\n\t"}${possibleBinaries.mkString("\n\t")}")
         case e =>
           val errorString =
             s"$e\n${rootCause(e).getStackTrace.to[List].map(_.toString).join("    at ", "\n    at ", "")}"

--- a/src/model/exception.scala
+++ b/src/model/exception.scala
@@ -30,6 +30,7 @@ case class InvalidValue(value: String) extends FuryException
 case class InitFailure() extends FuryException
 case class UnspecifiedProject() extends FuryException
 case class UnspecifiedModule() extends FuryException
+case class UnspecifiedBinary(matchingBinaries: List[String]) extends FuryException
 case class UnknownModule(moduleRef: ModuleRef) extends FuryException
 case class UnspecifiedMain(module: ModuleId) extends FuryException
 case class GraalVMError(message: String) extends FuryException


### PR DESCRIPTION
Fixes #318.
Binaries filter method for partial id match.
Unique binary match checking.
New exception for UnspecifiedBinary that lists all possible matches.