### PR TITLE
Restored the sparse checkout function to the way it looked before the IPFS merge.

### DIFF
--- a/src/core/shell.scala
+++ b/src/core/shell.scala
@@ -96,9 +96,8 @@ case class Shell(environment: Environment) {
       _   <- if(!sources.isEmpty) sh"git -C ${dir.value} config core.sparseCheckout true".exec[Try[String]]
              else Success(())
       _   <- ~(dir / ".git" / "info" / "sparse-checkout").writeSync(sources.map(_.value + "/*\n").mkString)
-      _   <- sh"git -C ${from.value} fetch".exec[Try[String]]
       _   <- sh"git -C ${dir.value} remote add origin ${from.value}".exec[Try[String]]
-      str <- sh"git -C ${dir.value} fetch origin".exec[Try[String]]
+      str <- sh"git -C ${dir.value} fetch origin $refSpec".exec[Try[String]]
       _   <- sh"git -C ${dir.value} checkout $commit".exec[Try[String]]
       _   <- ~(dir / ".done").touch()
     } yield str


### PR DESCRIPTION
This works with Git 2.21.0.