### PR TITLE
Sort manifest file classpath entries

### DIFF
--- a/src/utils/manifest.scala
+++ b/src/utils/manifest.scala
@@ -26,7 +26,7 @@ object Manifest {
     val mainAttributes = result.getMainAttributes
     mainAttributes.put(MANIFEST_VERSION, "1.0")
     mainClass.foreach(mainAttributes.put(MAIN_CLASS, _))
-    mainAttributes.put(CLASS_PATH, classpath.join(" "))
+    mainAttributes.put(CLASS_PATH, classpath.to[List].sorted.join(" "))
     mainAttributes.putValue("Created-By", str"Fury ${Version.current}")
     
     result

--- a/test/passing/fat-jar/check
+++ b/test/passing/fat-jar/check
@@ -28,8 +28,8 @@ HelloWorld.class
 Hello World
 0
 Manifest-Version: 1.0
-Class-Path: scala-library-2.12.8.jar scala-compiler-2.12.8.jar scala-x
- ml_2.12-1.0.6.jar scala-reflect-2.12.8.jar
+Class-Path: scala-compiler-2.12.8.jar scala-library-2.12.8.jar scala-r
+ eflect-2.12.8.jar scala-xml_2.12-1.0.6.jar
 Created-By: Fury 0.7.5
 Main-Class: HelloWorld
 

--- a/test/passing/save-jar/check
+++ b/test/passing/save-jar/check
@@ -30,8 +30,8 @@ HelloWorld$.class
 HelloWorld.class
 META-INF/MANIFEST.MF
 Manifest-Version: 1.0
-Class-Path: scala-library-2.12.8.jar scala-compiler-2.12.8.jar scala-x
- ml_2.12-1.0.6.jar scala-reflect-2.12.8.jar
+Class-Path: scala-compiler-2.12.8.jar scala-library-2.12.8.jar scala-r
+ eflect-2.12.8.jar scala-xml_2.12-1.0.6.jar
 Created-By: Fury 0.7.5
 Main-Class: HelloWorld
 


### PR DESCRIPTION
This should make the `Class-Path` entries in `MANIFEST.MF` files more stable, which will be useful for testing.