### PR TITLE
Revert "Configured build step order for the cloud build."

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,22 +7,16 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['run', '-w', '/build', '-t', 'fury/ci', 'make', 'test']
   timeout: 300s
-  waitFor:
-    - build
   id: 'unittests'
 
 - name: 'gcr.io/cloud-builders/docker'
   args: ['run', '-u', 'bash_user', '-w', '/home/bash_user', '-t', 'fury/ci', '/integration']
   timeout: 300s
-  waitFor:
-    - build
   id: 'integration'
 
 - name: 'gcr.io/cloud-builders/docker'
   args: ['run', '-u', 'bash_user', '-w', '/home/bash_user', '-t', 'fury/ci', '/community']
   timeout: 600s
-  waitFor:
-    - build
   id: 'community'
 
 options:


### PR DESCRIPTION
It looks like the parallel execution of test suites is very unreliable. In particular, the integration tests usually hand and time out.