### PR TITLE
Added a key to show the classpath in a more readable way.

### DIFF
--- a/src/core/args.scala
+++ b/src/core/args.scala
@@ -123,5 +123,6 @@ object Args {
   val VerboseArg = CliParam[Unit]('v', 'verbose, "Show more output")
   val VersionArg = CliParam[RefSpec]('V', 'version, "Git branch, tag or commit")
   val WatchArg = CliParam[Unit]('w', 'watch, "Watch for file changes")
+  val SingleColumnArg = CliParam[Unit]('1', Symbol("single-column"), "Print values in a single column")
   val ParamNoArg = Param[Int](' ', 'paramNo)
 }


### PR DESCRIPTION
```
$ fury build classpath -1
Starting Fury daemon.....done
/home/virtuslab/.cache/fury/bins/org.scala-lang/scala-compiler/2.12.8/scala-library-2.12.8.jar
/home/virtuslab/devel/cats/.fury/resources/default_cats_core
/home/virtuslab/devel/cats/.fury/classes/default_simulacrum_core
/home/virtuslab/devel/cats/.fury/resources/default_cats_free
/home/virtuslab/devel/cats/.fury/classes/default_macro-paradise_plugin
/home/virtuslab/devel/cats/.fury/classes/default_cats_kernel
/home/virtuslab/.cache/fury/bins/org.typelevel/kind-projector_2.12/0.10.3/kind-projector_2.12-0.10.3.jar
/home/virtuslab/devel/cats/.fury/resources/default_macro-paradise_plugin
/home/virtuslab/devel/cats/.fury/resources/default_simulacrum_core
/home/virtuslab/devel/cats/.fury/resources/scala-2.12.8_scala_compiler
/home/virtuslab/devel/cats/.fury/classes/default_kind-projector_plugin
/home/virtuslab/devel/cats/.fury/classes/default_cats_core
/home/virtuslab/.cache/fury/bins/org.scala-lang/scala-compiler/2.12.8/scala-compiler-2.12.8.jar
/home/virtuslab/devel/cats/.fury/classes/scala-2.12.8_scala_compiler
/home/virtuslab/.cache/fury/bins/org.scala-lang/scala-compiler/2.12.8/scala-reflect-2.12.8.jar
/home/virtuslab/devel/cats/.fury/resources/default_cats_kernel
/home/virtuslab/.cache/fury/bins/org.scala-lang/scala-compiler/2.12.8/scala-xml_2.12-1.0.6.jar
/home/virtuslab/devel/cats/.fury/classes/default_cats_free
/home/virtuslab/devel/cats/.fury/resources/default_kind-projector_plugin
```