### PR TITLE
Refactored the code that builds the compilation graph

### DIFF
--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -772,11 +772,11 @@ case class CompileResult(bspCompileResult: BspCompileResult, scalacOptions: Scal
 }
 
 object CompileResult {
-  def merge(results: List[CompileResult]): CompileResult = {
+  def merge(results: Iterable[CompileResult]): CompileResult = {
     CompileResult(merge(results.map(_.bspCompileResult)), merge(results.map(_.scalacOptions)))
   }
 
-  private def merge(results: List[BspCompileResult]): BspCompileResult = {
+  private def merge(results: Iterable[BspCompileResult]): BspCompileResult = {
     val distinctStatuses = results.map(_.getStatusCode).toSet
     val aggregatedStatus = List(StatusCode.CANCELLED, StatusCode.ERROR, StatusCode.OK).find(distinctStatuses.contains)
     val mergedResult = new BspCompileResult(aggregatedStatus.getOrElse(StatusCode.OK))
@@ -789,13 +789,13 @@ object CompileResult {
     mergedResult
   }
 
-  private def merge(results: List[ScalacOptionsResult]): ScalacOptionsResult = {
-    new ScalacOptionsResult(results.flatMap(_.getItems.asScala).asJava)
+  private def merge(results: Iterable[ScalacOptionsResult]): ScalacOptionsResult = {
+    new ScalacOptionsResult(results.flatMap(_.getItems.asScala).toList.asJava)
   }
 }
 
 object Target {
-  type Graph = Map[TargetId, List[TargetId]]
+  type Graph = Map[TargetId, Set[TargetId]]
 }
 
 case class Target(ref: ModuleRef,

--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -817,7 +817,6 @@ case class Target(ref: ModuleRef,
                   properties: Map[String, String]) {
 
   def id: TargetId = TargetId(schemaId, ref.projectId, ref.moduleId)
-  def executed = kind == Application || kind == Benchmarks
 }
 
 object Project {

--- a/src/core/reporter.scala
+++ b/src/core/reporter.scala
@@ -40,7 +40,7 @@ object GraphReporter extends Reporter("graph") {
              theme: Theme,
              multiplexer: Multiplexer[ModuleRef, CompileEvent])(implicit log: Log)
             : Unit = {
-    val modules = graph.map { case (k, v) => (k.ref, v.to[Set].map(_.ref)) }
+    val modules = graph.map { case (k, v) => (k.ref, v.map(_.ref)) }
     log.info(msg"Starting build")
     Graph.live(modules, multiplexer.stream(50, Some(Tick)))(log, theme)
     log.info(msg"Build completed")

--- a/test/passing/app-args/check
+++ b/test/passing/app-args/check
@@ -14,6 +14,9 @@ Starting the BSP launcher...
 Opening a BSP server connection
 Could not detect a BSP server running locally
 BSP server is listening for incoming connections
+Starting the BSP launcher...
+Opening a BSP server connection
+BSP server is listening for incoming connections
 Starting compilation of module hello-world/app
 Successfully compiled module hello-world/app
 arg1

--- a/test/passing/app-inputs/check
+++ b/test/passing/app-inputs/check
@@ -13,6 +13,9 @@ cd701b6615442f102ea7c636cdc16e194369a1556e049a32126b045faee45762
 Starting the BSP launcher...
 Opening a BSP server connection
 BSP server is listening for incoming connections
+Starting the BSP launcher...
+Opening a BSP server connection
+BSP server is listening for incoming connections
 Starting compilation of module example/app
 Successfully compiled module example/app
 Test:something

--- a/test/passing/binary-remove/check
+++ b/test/passing/binary-remove/check
@@ -31,6 +31,9 @@ Unable to identify target binary:
 Starting the BSP launcher...
 Opening a BSP server connection
 BSP server is listening for incoming connections
+Starting the BSP launcher...
+Opening a BSP server connection
+BSP server is listening for incoming connections
 Starting compilation of module hello-world/app
 Successfully compiled module hello-world/app
 Hello world!

--- a/test/passing/fat-jar/check
+++ b/test/passing/fat-jar/check
@@ -13,6 +13,9 @@ cd701b6615442f102ea7c636cdc16e194369a1556e049a32126b045faee45762
 Starting the BSP launcher...
 Opening a BSP server connection
 BSP server is listening for incoming connections
+Starting the BSP launcher...
+Opening a BSP server connection
+BSP server is listening for incoming connections
 Starting compilation of module bar/app
 Successfully compiled module bar/app
 Hello World

--- a/test/passing/hello-world/check
+++ b/test/passing/hello-world/check
@@ -14,6 +14,9 @@ b7d1eb536c388d4e9adf8dfbb4c0d69aa8c267030d616f6883c35e27efe2befd
 Starting the BSP launcher...
 Opening a BSP server connection
 BSP server is listening for incoming connections
+Starting the BSP launcher...
+Opening a BSP server connection
+BSP server is listening for incoming connections
 Starting compilation of module hello-world/app
 Successfully compiled module hello-world/app
 0

--- a/test/passing/missing-compiler/check
+++ b/test/passing/missing-compiler/check
@@ -18,6 +18,9 @@ b7d1eb536c388d4e9adf8dfbb4c0d69aa8c267030d616f6883c35e27efe2befd
 Starting the BSP launcher...
 Opening a BSP server connection
 BSP server is listening for incoming connections
+Starting the BSP launcher...
+Opening a BSP server connection
+BSP server is listening for incoming connections
 Starting compilation of module hello-world/app
 Successfully compiled module hello-world/app
 Hello World

--- a/test/passing/no-duplicate-success/check
+++ b/test/passing/no-duplicate-success/check
@@ -7,6 +7,9 @@ Set current module to app
 Starting the BSP launcher...
 Opening a BSP server connection
 BSP server is listening for incoming connections
+Starting the BSP launcher...
+Opening a BSP server connection
+BSP server is listening for incoming connections
 Starting compilation of module hello-world/app
 Successfully compiled module hello-world/app
 Hello world

--- a/test/passing/permission-granting/check
+++ b/test/passing/permission-granting/check
@@ -11,6 +11,9 @@ d42a730e5df5d6041cff16617a0cc9ad9f565162a1ad5fdcad5fa6f29c656dba
 Starting the BSP launcher...
 Opening a BSP server connection
 BSP server is listening for incoming connections
+Starting the BSP launcher...
+Opening a BSP server connection
+BSP server is listening for incoming connections
 Starting compilation of module hello-world/app
 Successfully compiled module hello-world/app
 All permissions in order!

--- a/test/passing/repo-fork/check
+++ b/test/passing/repo-fork/check
@@ -16,6 +16,9 @@ d42a730e5df5d6041cff16617a0cc9ad9f565162a1ad5fdcad5fa6f29c656dba
 Starting the BSP launcher...
 Opening a BSP server connection
 BSP server is listening for incoming connections
+Starting the BSP launcher...
+Opening a BSP server connection
+BSP server is listening for incoming connections
 Starting compilation of module library/core
 Successfully compiled module library/core
 Starting compilation of module hello-world/app
@@ -23,6 +26,9 @@ Successfully compiled module hello-world/app
 Hello fork!
 0
 Checking out src/core from repository library
+Starting the BSP launcher...
+Opening a BSP server connection
+BSP server is listening for incoming connections
 Starting the BSP launcher...
 Opening a BSP server connection
 BSP server is listening for incoming connections

--- a/test/passing/save-jar/check
+++ b/test/passing/save-jar/check
@@ -15,6 +15,9 @@ b7d1eb536c388d4e9adf8dfbb4c0d69aa8c267030d616f6883c35e27efe2befd
 Starting the BSP launcher...
 Opening a BSP server connection
 BSP server is listening for incoming connections
+Starting the BSP launcher...
+Opening a BSP server connection
+BSP server is listening for incoming connections
 Starting compilation of module foo/lib
 Successfully compiled module foo/lib
 Starting compilation of module foo/app

--- a/test/passing/scala3/check
+++ b/test/passing/scala3/check
@@ -7,6 +7,9 @@ Set current module to app
 Starting the BSP launcher...
 Opening a BSP server connection
 BSP server is listening for incoming connections
+Starting the BSP launcher...
+Opening a BSP server connection
+BSP server is listening for incoming connections
 Starting compilation of module hello-world/app
 Successfully compiled module hello-world/app
 0


### PR DESCRIPTION
 > By the way, you'll need to make another change to Fury to make this work... but it's quite simple: the code which builds the compile subgraphs needs to stop at a dependency on a plugin module, the same as it does with an application module.
Actually compiler modules, too.

I don't really understand why, but it worked.