### PR TITLE
Reduce the size of Fury cache under 400 MB

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
        key: ${{ runner.os }}-coursier-${{ hashFiles('layers/*') }}
     - uses: actions/cache@v1
       with:
-       path: ~/.cache/fury
+       path: ~/.cache/fury/repos
        key: ${{ runner.os }}-fury-${{ hashFiles('layers/*') }}
     - name: Run Makefile
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,6 +85,8 @@ jobs:
       with:
         name: community-logs-${{ runner.os }}
         path: community-logs.tar.gz
+    - name: Inspect cache
+      run: du -h ~/.cache/fury --max-depth 2        
     - name: Summary
       run: |
         ! ls -1 *.failed 2> /dev/null


### PR DESCRIPTION
Otherwise it [won't work](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy).