### PR TITLE
Bumped the version of actions/checkout to v2-beta.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2-beta
     - uses: actions/cache@v1
       with:
        path: ~/.cache/coursier


### PR DESCRIPTION
https://github.com/actions/checkout/commit/8461dbfed36a8af202384a5b1ee0f7f1bf947821#diff-04c6e90faac2675aa89e2176d2eec7d8

There is no point in checking out the branches that aren't used in the build.