### PR TITLE
The layer select command goes crazy when the layer name is wrong #782

### DIFF
--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -498,16 +498,24 @@ object LayerCli {
     layout    <- cli.layout
     baseLayer <- Layer.base(layout)
     schema    <- baseLayer.mainSchema
-    cli       <- cli.hint(LayerArg, ImportPath("/") :: schema.importTree(layout, true).getOrElse(Nil))
+    cli       <- cli.hint(LayerArg,  schema.importTree(layout, true).getOrElse(Nil))
     call      <- cli.call()
-    _         <- schema.importTree(layout, true)
+    layers    <- schema.importTree(layout, true)
     relPath   <- call(LayerArg)
+    -         <- verifyLayers(relPath, layers)
     focus     <- Layer.readFocus(layout)
     newPath   <- ~focus.path.dereference(relPath)
     newFocus  <- ~focus.copy(path = newPath)
     _         <- Layer.saveFocus(newFocus, layout)
   } yield log.await()
- 
+
+
+  def verifyLayers(path: ImportPath, list: List[ImportPath]): Try[Unit] =
+    if (list.map(_.path).contains(path.path))
+      Success()
+    else
+      Failure(LayersFailure(path))
+
   def extract(cli: Cli[CliParam[_]])(implicit log: Log): Try[ExitStatus] = for {
     cli      <- cli.hint(DirArg)
     cli      <- cli.hint(FileArg)

--- a/src/frontend/recovery.scala
+++ b/src/frontend/recovery.scala
@@ -134,6 +134,8 @@ You can grant these permissions with,
           cli.abort(msg"Binary not found.")
         case UnspecifiedBinary(possibleBinaries) =>
           cli.abort(msg"Unable to identify target binary: ${"\n\t"}${possibleBinaries.mkString("\n\t")}")
+        case LayersFailure(layerPath) =>
+          cli.abort(msg"Layer name ${layerPath.path} not found.")
         case e =>
           val errorString =
             s"\n$e\n${rootCause(e).getStackTrace.to[List].map(_.toString).join("    at ", "\n    at ", "")}"

--- a/src/model/exception.scala
+++ b/src/model/exception.scala
@@ -50,6 +50,7 @@ case class CompilationFailure() extends FuryException
 case class DownloadFailure(detail: String) extends FuryException
 case class CyclesInDependencies(cycle: Set[ModuleRef]) extends FuryException
 case class BspException() extends FuryException
+case class LayersFailure(layer: ImportPath) extends FuryException
 
 object ItemNotFound {
   def apply[K <: Key: MsgShow](key: K): ItemNotFound = ItemNotFound(implicitly[MsgShow[K]].show(key), key.kind)

--- a/src/model/ids.scala
+++ b/src/model/ids.scala
@@ -73,7 +73,7 @@ case class ModuleId(key: String) extends Key(msg"module")
 object ImportPath {
   implicit val msgShow: MsgShow[ImportPath] = ip => UserMsg(_.layer(ip.path))
   implicit val stringShow: StringShow[ImportPath] = _.path
-  val Root: ImportPath = ImportPath("")
+  val Root: ImportPath = ImportPath("/") //Can i change this?
 
   // FIXME: Actually parse it and check that it's valid
   def parse(str: String): Option[ImportPath] =


### PR DESCRIPTION
Create a function to verify if a layer exists.
New exception LayersFailure that is thrown when the given name doesn't exist.
Change the Root ImportPath from ImportPath("") to ImportPath("/")

ref: layerSelectCommand