### PR TITLE
The layer select command goes crazy when the layer name is wrong #782 V2

### DIFF
--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -498,13 +498,13 @@ object LayerCli {
     layout    <- cli.layout
     baseLayer <- Layer.base(layout)
     schema    <- baseLayer.mainSchema
-    cli       <- cli.hint(LayerArg,  schema.importTree(layout, true).getOrElse(Nil))
+    cli       <- cli.hint(LayerArg, schema.importTree(layout, true).getOrElse(Nil))
     call      <- cli.call()
     layers    <- schema.importTree(layout, true)
     relPath   <- call(LayerArg)
-    -         <- verifyLayers(relPath, layers)
     focus     <- Layer.readFocus(layout)
     newPath   <- ~focus.path.dereference(relPath)
+    -         <- verifyLayers(newPath, layers)
     newFocus  <- ~focus.copy(path = newPath)
     _         <- Layer.saveFocus(newFocus, layout)
   } yield log.await()

--- a/src/model/ids.scala
+++ b/src/model/ids.scala
@@ -73,7 +73,7 @@ case class ModuleId(key: String) extends Key(msg"module")
 object ImportPath {
   implicit val msgShow: MsgShow[ImportPath] = ip => UserMsg(_.layer(ip.path))
   implicit val stringShow: StringShow[ImportPath] = _.path
-  val Root: ImportPath = ImportPath("/") //Can i change this?
+  val Root: ImportPath = ImportPath("/")
 
   // FIXME: Actually parse it and check that it's valid
   def parse(str: String): Option[ImportPath] =
@@ -101,9 +101,11 @@ case class ImportPath(path: String) {
   def dereference(relPath: ImportPath): ImportPath =
     if(relPath.path.startsWith("/")) relPath
     else {
-      rawParts match {
-        case ".." :: tail => ImportPath(rawParts.dropRight(1).mkString("/")).dereference(ImportPath(tail.mkString("/")))
-        case xs => ImportPath((rawParts ++ xs).mkString("/"))
+      val value = relPath.path.split("/").to[List]
+      value match {
+        case ".." :: tail =>
+          ImportPath(value.dropRight(1).mkString("/")).dereference(ImportPath(tail.mkString("/")))
+        case _            => ImportPath("/" + value.mkString("/"))
       }
     }
 }


### PR DESCRIPTION
V1 - previous related PR
Create a function to verify if a layer exists.
New exception LayersFailure that is thrown when the given name doesn't exist.
Change the Root ImportPath from ImportPath("") to ImportPath("/")

V2 - new version of fix

now it handles '..'

If we are in /platform and we select '..' we return to /.
If we select 'platform',  it get converted to '/platform'.

ref: layerSelectCommandV2