### PR TITLE
Refactored ImportPath to use java.nio.file.Path internally.

### DIFF
--- a/src/core/data.scala
+++ b/src/core/data.scala
@@ -495,7 +495,7 @@ object Layer {
   } yield layerRef
 
   private def saveSchema(layout: Layout, newLayer: Layer, path: ImportPath, currentLayer: Layer)(implicit log: Log): Try[LayerRef] =
-    if(path.isEmpty) saveLayer(newLayer)
+    if(path.isRoot) saveLayer(newLayer)
     else for {
       schema    <- currentLayer.mainSchema
       schemaRef <- schema.imports.findBy(path.head)

--- a/src/frontend/recovery.scala
+++ b/src/frontend/recovery.scala
@@ -135,7 +135,7 @@ You can grant these permissions with,
         case UnspecifiedBinary(possibleBinaries) =>
           cli.abort(msg"Unable to identify target binary: ${"\n\t"}${possibleBinaries.mkString("\n\t")}")
         case LayersFailure(layerPath) =>
-          cli.abort(msg"Layer name ${layerPath.path} not found.")
+          cli.abort(msg"Layer name $layerPath not found.")
         case e =>
           val errorString =
             s"\n$e\n${rootCause(e).getStackTrace.to[List].map(_.toString).join("    at ", "\n    at ", "")}"

--- a/src/model-test/importpaths.scala
+++ b/src/model-test/importpaths.scala
@@ -34,43 +34,43 @@ object ImportPathTests extends TestApp {
     val nestedRelativePath = ImportPath("baz/quux")
 
     test("root path head & tail") {
-      root.isEmpty &&
+      root.isRoot &&
       Try(root.head).isFailure &&
       Try(root.tail).isFailure
     }.assert(_ == true)
 
     test("current path head & tail") {
-      here.isEmpty &&
+      here.isRoot &&
         Try(here.head).isFailure &&
         Try(here.tail).isFailure
     }.assert(_ == true)
 
     test("parent path head & tail") {
-      parent.isEmpty &&
+      parent.isRoot &&
         Try(parent.head).isFailure &&
         Try(parent.tail).isFailure
     }.assert(_ == true)
 
     test("absolute path head & tail") {
-      !absolutePath.isEmpty &&
+      !absolutePath.isRoot &&
         Try(absolutePath.head) == Success(ImportId("foo")) &&
         Try(absolutePath.tail) == Success(ImportPath("/"))
     }.assert(_ == true)
 
     test("relative path head & tail") {
-      relativePath.isEmpty &&
+      relativePath.isRoot &&
         Try(relativePath.head).isFailure &&
         Try(relativePath.tail).isFailure
     }.assert(_ == true)
 
     test("nested absolute path head & tail") {
-      !nestedAbsolutePath.isEmpty &&
+      !nestedAbsolutePath.isRoot &&
         Try(nestedAbsolutePath.head) == Success(ImportId("foo")) &&
         Try(nestedAbsolutePath.tail) == Success(ImportPath("/bar"))
     }.assert(_ == true)
 
     test("nested relative path head & tail") {
-      nestedRelativePath.isEmpty &&
+      nestedRelativePath.isRoot &&
         Try(nestedRelativePath.head).isFailure &&
         Try(nestedRelativePath.tail).isFailure
     }.assert(_ == true)

--- a/src/model/ids.scala
+++ b/src/model/ids.scala
@@ -89,7 +89,7 @@ case class ImportPath(path: Path) {
 
   private[this] val rawParts: List[String] = path.iterator.asScala.map(_.toString).to[List]
 
-  private[this] val parts: List[ImportId] = rawParts.map(ImportId(_))
+  val parts: List[ImportId] = rawParts.map(ImportId(_))
 
   def /(importId: ImportId): ImportPath = ImportPath(path.resolve(importId.key))
   def tail: ImportPath = ImportPath(Paths.get("", rawParts.tail : _*))

--- a/src/ogdl/ogdlreader.scala
+++ b/src/ogdl/ogdlreader.scala
@@ -17,6 +17,7 @@
 package fury.ogdl
 
 import magnolia._
+import java.nio.file.{Path, Paths}
 
 import scala.collection.generic.CanBuildFrom
 import scala.language.experimental.macros
@@ -58,6 +59,7 @@ object OgdlReader {
   implicit val int: OgdlReader[Int]         = _().toInt
   implicit val long: OgdlReader[Long]       = _().toLong
   implicit val boolean: OgdlReader[Boolean] = _().toBoolean
+  implicit val jpath: OgdlReader[Path]      = ogdl => Paths.get(ogdl())
 
   implicit def traversable[Coll[t] <: Traversable[t], T: OgdlReader](
       implicit cbf: CanBuildFrom[Nothing, T, Coll[T]]

--- a/src/ogdl/ogdlwriter.scala
+++ b/src/ogdl/ogdlwriter.scala
@@ -19,6 +19,7 @@ package fury.ogdl
 import fury.strings._
 
 import magnolia.{CaseClass, Magnolia, SealedTrait}
+import java.nio.file.{Path, Paths}
 
 import scala.collection.immutable.SortedSet
 import scala.language.experimental.macros
@@ -53,6 +54,7 @@ object OgdlWriter {
   implicit val int: OgdlWriter[Int]         = i => Ogdl(i.toString)
   implicit val long: OgdlWriter[Long]       = l => Ogdl(l.toString)
   implicit val boolean: OgdlWriter[Boolean] = b => Ogdl(b.toString)
+  implicit val jpath: OgdlWriter[Path]      = b => Ogdl(b.toString)
 
   implicit def list[T: OgdlWriter: StringShow]: OgdlWriter[List[T]] =
     coll =>


### PR DESCRIPTION
This pull request doesn't affect the application logic, but it makes the internal workings of `ImportPath` a little bit simpler.