### PR TITLE
Make the `-d` option optional when cloning a layer

### DIFF
--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -537,7 +537,7 @@ object LayerCli {
       case IpfsImport(hash) => Layer.loadFromIpfs(hash, cli.env)
       case imp => Layer.resolve(Layer.follow(imp), cli.env)
     }
-    dir           <- call(DirArg)
+    dir           <- call(DirArg).pacify(call(ImportArg).toOption.flatMap(_.dirSuggestion))
     pwd           <- cli.pwd
     dir           <- ~pwd.resolve(dir)
     _             <- ~dir.mkdir()

--- a/src/core/package.scala
+++ b/src/core/package.scala
@@ -42,4 +42,14 @@ object `package` {
   implicit class Unitize[T](t: T) { def unit: Unit = ()         }
   implicit class Waive[T](t: T) { def waive[S]: S => T = { _ => t } }
   implicit class AutoRight[T](t: T) { def unary_~ : Try[T] = Success(t) }
+
+  implicit class TryExtensions[T](t: Try[T]) {
+    def pacify(alternative: => Option[T]): Try[T] = t match {
+      case Success(v) => t
+      case Failure(e) => alternative match {
+        case Some(v) => Success(v)
+        case None => t
+      }
+    }
+  }
 }

--- a/src/model/ids.scala
+++ b/src/model/ids.scala
@@ -379,10 +379,18 @@ object ImportLayer {
   }
 }
 
-sealed trait ImportLayer
-case class IpfsImport(hash: IpfsRef) extends ImportLayer
-case class RefImport(followable: Followable) extends ImportLayer
-case class DefaultImport(path: String) extends ImportLayer
+sealed trait ImportLayer { def dirSuggestion: Option[Path] }
+case class IpfsImport(hash: IpfsRef) extends ImportLayer {
+  def dirSuggestion: Option[Path] = None
+}
+
+case class RefImport(followable: Followable) extends ImportLayer {
+  def dirSuggestion: Option[Path] = Some(followable.path.split("/").last).map(Path(_))
+}
+
+case class DefaultImport(path: String) extends ImportLayer {
+  def dirSuggestion: Option[Path] = Some(path.split("/").last).map(Path(_))
+}
 
 object Followable {
   implicit val msgShow: MsgShow[Followable] = fl => UserMsg { theme =>


### PR DESCRIPTION
This will suggest the name of the directory from the name of the layer.

Currently this only makes sense for `organization/project` style layer
names, not more general ones.