### PR TITLE
Support for "short form" commands

### DIFF
--- a/src/core/cli.scala
+++ b/src/core/cli.scala
@@ -144,7 +144,11 @@ case class Cli[+Hinted <: CliParam[_]](stdout: java.io.PrintWriter,
   def next: Option[String] = args.prefix.headOption.map(_.value)
   def completion: Boolean = command.isDefined
   def prefix(str: String): Cli[Hinted] = copy(args = ParamMap((str :: args.args.to[List]): _*))
-  def tail: Cli[Hinted] = copy(args = args.tail)
+  
+  def tail: Cli[Hinted] =
+    if(args.headOption.map(_.length) == Some(2)) copy(args = ParamMap(args.args.head.tail +: args.args.tail: _*))
+    else copy(args = args.tail)
+  
   def opt[T: Default](param: CliParam[T]): Try[Option[T]] = Success(args(param.param).toOption)
 
   def abort(msg: UserMsg): ExitStatus = {

--- a/src/core/structure.scala
+++ b/src/core/structure.scala
@@ -24,13 +24,15 @@ sealed trait MenuStructure[T] {
   def command: Symbol
   def description: UserMsg
   def show: Boolean
+  def shortcut: Char
 }
 
 case class Action[T](
     command: Symbol,
     description: UserMsg,
     action: T => Try[ExitStatus],
-    show: Boolean = true)
+    show: Boolean = true,
+    shortcut: Char = '\u0000')
     extends MenuStructure[T]
 
 case class Menu[T, S](
@@ -38,7 +40,8 @@ case class Menu[T, S](
     description: UserMsg,
     action: T => Try[S],
     default: Symbol,
-    show: Boolean = true
+    show: Boolean = true,
+    shortcut: Char = '\u0000'
   )(val items: MenuStructure[S]*)
     extends MenuStructure[T] {
 
@@ -48,25 +51,39 @@ case class Menu[T, S](
         if(cli.completion) cli.completeCommand(this)
         else apply(cli.prefix(default.name), ctx)
       case Some(next) =>
-        items.find(_.command.name == next.value) match {
+        val cmd = items.find(_.command.name == next.value).orElse {
+          if(next.value.length <= 2) items.find(_.shortcut == next.value(0))
+          else None
+        }
+
+        cmd match {
           case None =>
             if(cli.completion) cli.completeCommand(this)
             else Failure(UnknownCommand(next.value))
-          case Some(item @ Menu(_, _, _, _, _)) =>
+          case Some(item @ Menu(_, _, _, _, _, _)) =>
             action(ctx).flatMap(item(cli.tail, _))
-          case Some(item @ Action(_, _, _, _)) =>
+          case Some(item @ Action(_, _, _, _, _)) =>
             action(ctx).flatMap(item.action)
         }
     }
 
   def reference(implicit theme: Theme): Seq[String] = {
+
+    def highlight(str: String, char: Char): UserMsg = if(char == '\u0000') msg"$str" else {
+      val idx = str.indexOf(str)
+      val left = str.substring(0, idx)
+      val right = str.substring(idx + 1)
+
+      UserMsg { theme => msg"$left${theme.underline(char.toString)}$right".string(theme) }
+    }
+
     val shownItems = items.filter(_.show)
     val width      = 12
     shownItems.sortBy { case _: Action[_] => 0; case _ => 1 }.flatMap {
       case item: Action[_] =>
-        List(msg"  ${item.command.name.padTo(width, ' ')} ${item.description}".string(theme))
+        List(msg"  ${highlight(item.command.name.padTo(width, ' '), item.shortcut)} ${item.description}".string(theme))
       case item: Menu[_, _] =>
-        "" +: msg"  ${item.command.name.padTo(width, ' ')} ${item.description}".string(theme) +:
+        "" +: msg"  ${highlight(item.command.name.padTo(width, ' '), item.shortcut)} ${item.description}".string(theme) +:
           item.reference.map("  " + _)
     }
   }

--- a/src/frontend/menu.scala
+++ b/src/frontend/menu.scala
@@ -31,10 +31,10 @@ object FuryMenu {
             Action('list, msg"list command aliases", AliasCli.list)
         ),
         Action('bsp, msg"start BSP server", Bsp.startServer, false),
-        Menu('binary, msg"manage binary dependencies for the module", BinaryCli.context, 'list)(
-            Action('add, msg"add a binary dependency to the module", BinaryCli.add),
-            Action('remove, msg"remove a binary dependency from the module", BinaryCli.remove),
-            Action('list, msg"list binary dependencies for the module", BinaryCli.list)
+        Menu('binary, msg"manage binary dependencies for the module", BinaryCli.context, 'list, shortcut = 'b')(
+            Action('add, msg"add a binary dependency to the module", BinaryCli.add, shortcut = 'a'),
+            Action('remove, msg"remove a binary dependency from the module", BinaryCli.remove, shortcut = 'r'),
+            Action('list, msg"list binary dependencies for the module", BinaryCli.list, shortcut = 'l')
         ),
         Menu('build, msg"perform build actions", BuildCli.context, 'run)(
             Action('classpath, msg"show a classpath for a module", BuildCli.classpath),
@@ -57,24 +57,24 @@ object FuryMenu {
             Action('set, msg"change a settings", ConfigCli.set),
             Action('auth, msg"authenticate using the distribution service", ConfigCli.auth)
         ),
-        Menu('dependency, msg"manage dependencies for the module", DependencyCli.context, 'list)(
-            Action('add, msg"add a dependency on another module", DependencyCli.add),
-            Action('remove, msg"remove a dependency", DependencyCli.remove),
-            Action('list, msg"list dependencies for the module", DependencyCli.list)
+        Menu('dependency, msg"manage dependencies for the module", DependencyCli.context, 'list, shortcut = 'd')(
+            Action('add, msg"add a dependency on another module", DependencyCli.add, shortcut = 'a'),
+            Action('remove, msg"remove a dependency", DependencyCli.remove, shortcut = 'r'),
+            Action('list, msg"list dependencies for the module", DependencyCli.list, shortcut = 'l')
         ),
-        Menu('env, msg"manage application environment variables", EnvCli.context, 'list)(
-            Action('add, msg"add an environment variable", EnvCli.add),
-            Action('remove, msg"remove an environment variable", EnvCli.remove),
-            Action('list, msg"list environment variable", EnvCli.list)
+        Menu('env, msg"manage application environment variables", EnvCli.context, 'list, shortcut = 'e')(
+            Action('add, msg"add an environment variable", EnvCli.add, shortcut = 'a'),
+            Action('remove, msg"remove an environment variable", EnvCli.remove, shortcut = 'r'),
+            Action('list, msg"list environment variable", EnvCli.list, shortcut = 'l')
         ),
         Action('help, msg"help on using Fury", help),
         Action('kill, msg"kill the Fury server", BuildCli.notImplemented),
-        Menu('module, msg"view and edit modules", ModuleCli.context, 'list)(
-            Action('add, msg"add a new module to the project", ModuleCli.add),
-            Action('remove, msg"remove a module from the project", ModuleCli.remove),
-            Action('list, msg"list modules for the project", ModuleCli.list),
-            Action('select, msg"select the current module", ModuleCli.select),
-            Action('update, msg"update the module", ModuleCli.update)
+        Menu('module, msg"view and edit modules", ModuleCli.context, 'list, shortcut = 'm')(
+            Action('add, msg"add a new module to the project", ModuleCli.add, shortcut = 'a'),
+            Action('remove, msg"remove a module from the project", ModuleCli.remove, shortcut = 'r'),
+            Action('list, msg"list modules for the project", ModuleCli.list, shortcut = 'l'),
+            Action('select, msg"select the current module", ModuleCli.select, shortcut = 's'),
+            Action('update, msg"update the module", ModuleCli.update, shortcut = 'u')
         ),
         Menu('param, msg"manage compiler parameters for the module", ParamCli.context, 'list)(
             Action('add, msg"add a compiler parameter to the module", ParamCli.add),
@@ -87,12 +87,12 @@ object FuryMenu {
             Action('obviate, msg"remove an application permission", PermissionCli.obviate),
             Action('require, msg"add an application permission", PermissionCli.require)
         ),
-        Menu('project, msg"manage projects", ProjectCli.context, 'list)(
-            Action('add, msg"add a new project to the schema", ProjectCli.add),
-            Action('remove, msg"remove a project from the schema", ProjectCli.remove),
-            Action('list, msg"list projects for the schema", ProjectCli.list),
-            Action('select, msg"select the current project", ProjectCli.select),
-            Action('update, msg"update a project", ProjectCli.update)
+        Menu('project, msg"manage projects", ProjectCli.context, 'list, shortcut = 'p')(
+            Action('add, msg"add a new project to the schema", ProjectCli.add, shortcut = 'a'),
+            Action('remove, msg"remove a project from the schema", ProjectCli.remove, shortcut = 'r'),
+            Action('list, msg"list projects for the schema", ProjectCli.list, shortcut = 'l'),
+            Action('select, msg"select the current project", ProjectCli.select, shortcut = 's'),
+            Action('update, msg"update a project", ProjectCli.update, shortcut = 'u')
         ),
         Action('prompt, msg"show a context prompt", BuildCli.prompt, false),
         Menu('property, msg"manage application -D properties", PropertyCli.context, 'list)(
@@ -101,10 +101,10 @@ object FuryMenu {
             Action('list, msg"list -D properties", PropertyCli.list)
         ),
         Action('restart, msg"restart the Fury server", BuildCli.notImplemented),
-        Menu('source, msg"manage sources for the module", SourceCli.context, 'list)(
-            Action('add, msg"add a source directory to the module", SourceCli.add),
-            Action('remove, msg"remove a source directory from the module", SourceCli.remove),
-            Action('list, msg"list sources for the module", SourceCli.list)
+        Menu('source, msg"manage sources for the module", SourceCli.context, 'list, shortcut = 's')(
+            Action('add, msg"add a source directory to the module", SourceCli.add, shortcut = 'a'),
+            Action('remove, msg"remove a source directory from the module", SourceCli.remove, shortcut = 'r'),
+            Action('list, msg"list sources for the module", SourceCli.list, shortcut = 'l')
         ),
         Action('stop, msg"gracefully shut down the Fury server", ((_: Cli[CliParam[_]]) => Lifecycle.shutdown())),
         Menu('schema, msg"manage the current schema", SchemaCli.context, 'list)(
@@ -115,31 +115,31 @@ object FuryMenu {
             Action('select, msg"select the current schema", SchemaCli.select),
             Action('update, msg"update a schema", SchemaCli.update)
         ),
-        Menu('repo, msg"manage source repositories for the schema", RepoCli.context, 'list)(
-            Action('add, msg"add a source repository to the schema", RepoCli.add),
-            Action('update, msg"update a source repository", RepoCli.update),
-            Action('remove, msg"remove a source repository from the schema", RepoCli.remove),
-            Action('fork, msg"fork a managed repository locally", RepoCli.fork),
+        Menu('repo, msg"manage source repositories for the schema", RepoCli.context, 'list, shortcut = 'r')(
+            Action('add, msg"add a source repository to the schema", RepoCli.add, shortcut = 'a'),
+            Action('update, msg"update a source repository", RepoCli.update, shortcut = 'u'),
+            Action('remove, msg"remove a source repository from the schema", RepoCli.remove, shortcut = 'r'),
+            Action('fork, msg"fork a managed repository locally", RepoCli.fork, shortcut = 'f'),
             Action('unfork, msg"restore a source repository to a managed checkout", RepoCli.unfork),
-            Action('list, msg"list source repositories", RepoCli.list),
+            Action('list, msg"list source repositories", RepoCli.list, shortcut = 'l'),
             Action(
                 'pull,
                 msg"pull the latest version of the source repo from the remote",
-                RepoCli.pull)
+                RepoCli.pull, shortcut = 'p')
         ),
         Action('upgrade, msg"upgrade to the latest version of Fury", BuildCli.upgrade),
         //Action('undo, msg"undo the previous modification", BuildCli.undo),
-        Menu('layer, msg"view and edit the layer", (t: Cli[CliParam[_]]) => Try(t), 'projects)(
-            Action('clone, msg"clone an external layer", LayerCli.clone),
-            Action('export, msg"export a layer to a file", LayerCli.export),
+        Menu('layer, msg"view and edit the layer", (t: Cli[CliParam[_]]) => Try(t), 'projects, shortcut = 'l')(
+            Action('clone, msg"clone an external layer", LayerCli.clone, shortcut = 'c'),
+            Action('export, msg"export a layer to a file", LayerCli.export, shortcut = 'e'),
             Action('extract, msg"extract a layer file", LayerCli.extract),
-            Action('import, msg"import an external layer", LayerCli.addImport),
+            Action('import, msg"import an external layer", LayerCli.addImport, shortcut = 'i'),
             Action('init, msg"initialize a new Fury layer", LayerCli.init),
-            Action('list, msg"list imported layers", LayerCli.list),
+            Action('list, msg"list imported layers", LayerCli.list, shortcut = 'l'),
             Action('projects, msg"show all available projects", LayerCli.projects),
-            Action('publish, msg"publish a layer", LayerCli.publish),
+            Action('publish, msg"publish a layer", LayerCli.publish, shortcut = 'p'),
             Action('unimport, msg"remove a previously imported layer", LayerCli.unimport),
-            Action('select, msg"select a layer", LayerCli.select),
+            Action('select, msg"select a layer", LayerCli.select, shortcut = 's'),
             Action('share, msg"share this layer", LayerCli.share),
         )
     ) ::: aliases: _*)
@@ -150,7 +150,7 @@ object FuryMenu {
       _     <- ~log.raw(s"""|Usage: fury <command> [<subcommands>] [<args>]
                            |
                            |Command and subcommand reference:
-                           |${menu(Nil).reference(Theme.NoColor).join("\n")}
+                           |${menu(Nil).reference(ManagedConfig().theme).join("\n")}
                            |
                            |More help is available on the Fury website: https://fury.build/
                            |""".stripMargin)


### PR DESCRIPTION
It is now possible to run "short versions" of commands, instead of typing everything out in full.

These always take the form of two-letter commands, where each letter expands to a longer command beginning with that letter.

For example, `fury project add ...` could be written as, `fury pa ...`

There is no tab-completion on these commands.

The `fury help` command will show a list of all the commands, with the shortcut character underlined, where it is supported.