### PR TITLE
Introduce script for running tests when code changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,15 @@ all: dist/bundle/lib/fury-frontend.jar
 publish-ipfs: dist/fury-$(VERSION).tar.gz
 	@ipfs add dist/fury-$(VERSION).tar.gz
 
+watch:
+	@echo "Run,"
+	@echo
+	@echo "    etc/react <test name>"
+	@echo
+	@echo "in another terminal to run an integration test upon a successful build"
+	@echo
+	fury build save -w -d dist/bundle/lib --output linear
+
 publish: dist/install.sh
 	git tag "v$(VERSION)" -m "Version $(VERSION)"
 	gsutil -h "Cache-Control:public,max-age=60" cp $< gs://downloads.furore.dev/fury-$(VERSION).sh

--- a/etc/fury
+++ b/etc/fury
@@ -1,18 +1,20 @@
 #!/bin/bash
 
 if [ "$(uname -s)" = 'Linux' ]; then
-  FURYHOME="$(realpath $(dirname "$(readlink -f "$0")")/..)"
+  DEFAULT_FURY_HOME="$(realpath $(dirname "$(readlink -f "$0")")/..)"
 else
-  FURYHOME="$(cd "$(dirname "$0")"/.. && pwd -P)"
+  DEFAULT_FURY_HOME="$(cd "$(dirname "$0")"/.. && pwd -P)"
 fi
 
 ARGS="$@"
-PORT="8462"
-CLASSPATH="$(cat $FURYHOME/classpath):$FURYHOME/lib/*"
+DEFAULT_PORT="8462"
+PORT=${FURY_PORT:-$DEFAULT_PORT}
+FHOME=${FURY_HOME:-$DEFAULT_FURY_HOME}
+CLASSPATH="$(cat $FHOME/classpath):$FHOME/lib/*"
 MAIN="com.facebook.nailgun.NGServer"
 FURY_MAIN="fury.Main"
 QUIET='0'
-UPGRADEDIR="$FURYHOME/upgrade"
+UPGRADEDIR="$FHOME/upgrade"
 SCALA_VERSION="2.12.8"
 NAILGUN_VERSION="1.0.0"
 
@@ -32,10 +34,10 @@ cleanup() {
 }
 
 nailgun() {
-  if ! sh -c "${FURYHOME}/bin/ng --nailgun-version > /dev/null 2>&1" || [[ "1" -eq "$USE_NG_PY" ]] ; then 
-	"${FURYHOME}"/bin/ng.py --nailgun-port "$PORT" "$1" -- "${@:2}"
+  if ! sh -c "${FHOME}/bin/ng --nailgun-version > /dev/null 2>&1" || [[ "1" -eq "$USE_NG_PY" ]] ; then 
+	"${FHOME}"/bin/ng.py --nailgun-port "$PORT" "$1" -- "${@:2}"
   else
-	"${FURYHOME}"/bin/ng --nailgun-port "$PORT" "$1" "${@:2}"
+	"${FHOME}"/bin/ng --nailgun-port "$PORT" "$1" "${@:2}"
   fi
 }
 
@@ -74,7 +76,7 @@ silently() {
 }
 
 coursier() {
-  "${FURYHOME}/bin/coursier" "$@"
+  "${FHOME}/bin/coursier" "$@"
 }
 
 killFury() {
@@ -109,13 +111,13 @@ alive() {
 
 startNailgun() {
   if [ -d "${UPGRADEDIR}" ]; then
-    source "${UPGRADEDIR}/bin/upgrade" && ${FURYHOME}/bin/fury "$ARGS"
+    source "${UPGRADEDIR}/bin/upgrade" && ${FHOME}/bin/fury "$ARGS"
     exit $?
   else
     if [ "$1" = "prompt" ]; then
       message 'Starting Fury daemon...'
     fi
-    java -Dfury.home="${FURYHOME}" -cp "$CLASSPATH" "$MAIN" "$PORT" > /dev/null &
+    java -Dfury.home="${FHOME}" -cp "$CLASSPATH" "$MAIN" "$PORT" > /dev/null &
     until (alive); do
       if [ "$1" = "prompt" ]; then
         message '.'
@@ -141,7 +143,7 @@ restartFury() {
 }
 
 startFuryStandalone() {
-  java -Dfury.home="${FURYHOME}" -cp "$CLASSPATH" "$FURY_MAIN" "$$" "$@"
+  java -Dfury.home="${FHOME}" -cp "$CLASSPATH" "$FURY_MAIN" "$$" "$@"
 }
 
 case "$1" in

--- a/etc/integration
+++ b/etc/integration
@@ -47,11 +47,11 @@ runtest() {
 mkdir -pv ~/.local/share/fury/layers
 mkdir -pv ~/.cache/fury/policies
 
-if [ "$1" = "" ]; then
+fury start
+fury clean
+fury config set --theme nocolor --timestamps off
 
-  fury start
-  fury clean
-  fury config set --theme nocolor --timestamps off
+if [ "$1" = "" ]; then
 
   for ATEST in $(ls $ROOT/test/passing); do
     let ACOUNT="$ACOUNT+1"

--- a/etc/react
+++ b/etc/react
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+mkdir -p .sandbox
+cp $HOME/.fury/classpath .sandbox/ # FIXME: Don't assume Fury is installed here
+
+export FURY_PORT="8463"
+if [ "$(uname -s)" = 'Linux' ]; then
+  export FURY_HOME="$(realpath $(dirname "$(readlink -f "$0")")/..)/.sandbox"
+else
+  export FURY_HOME="$(cd "$(dirname "$0")"/.. && pwd -P)/.sandbox"
+fi
+
+export PATH="$FURY_HOME/bin:$PATH"
+TEST="$1"
+
+init() {
+  cp -r dist/bundle/* .sandbox/
+}
+
+watchAndWait() {
+  init
+  fury start
+  echo "Running test $TEST..."
+  source etc/integration "$TEST"
+  fury kill
+  inotifywait -q --event close_write dist/bundle/lib/fury-frontend.jar test/*/$TEST/script test/*/$TEST/check && echo "Changes detected at $(date +%r)."
+  watchAndWait
+}
+
+watchAndWait

--- a/etc/react
+++ b/etc/react
@@ -3,7 +3,9 @@
 mkdir -p .sandbox
 cp $HOME/.fury/classpath .sandbox/ # FIXME: Don't assume Fury is installed here
 
+export XDG_CONFIG_DIR="${PWD}/.sandbox/.config"
 export FURY_PORT="8463"
+
 if [ "$(uname -s)" = 'Linux' ]; then
   export FURY_HOME="$(realpath $(dirname "$(readlink -f "$0")")/..)/.sandbox"
 else


### PR DESCRIPTION
This provides the

	make watch

command which will start fury in "watch" mode. Alongside this invocation, the `etc/react` script should be run with a test name, to repeatedly run that integration test whenever a successful build finishes, using `inotify`. Changes to the integration test script or `check` file will also trigger a rerun of the test.

The instance of Fury used for testing will be kept as isolated as possible from the main system installation, running on a different port, and installed in a separate directory.