### PR TITLE
Better management of multiplexers and command line sessions

### DIFF
--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -448,7 +448,8 @@ object BuildCli {
       _            <- compilation.checkoutAll(layout, https)
     } yield {
       val multiplexer = new Multiplexer[ModuleRef, CompileEvent](compilation.targets.map(_._1).to[List])
-      val future = compilation.compile(moduleRef, multiplexer, Map(), layout,
+      Lifecycle.currentSession.multiplexer = multiplexer
+      val future = compilation.compile(moduleRef, Map(), layout,
         globalPolicy, compileArgs, pipelining).apply(TargetId(schema.id, moduleRef)).andThen {
         case compRes =>
           multiplexer.closeAll()

--- a/src/compile/bsp.scala
+++ b/src/compile/bsp.scala
@@ -288,7 +288,9 @@ class FuryBuildServer(layout: Layout, cancel: Cancelator, https: Boolean) extend
         moduleRef <- struct.moduleRef(bspTargetId)
       } yield {
         val multiplexer = new fury.utils.Multiplexer[ModuleRef, CompileEvent](compilation.targets.map(_._1).to[List])
-        val compilationTasks = compilation.compile(moduleRef, multiplexer, Map.empty, layout, globalPolicy, List.empty, pipelining = false)
+        val session = Lifecycle.currentSession(log)
+        session.multiplexer = multiplexer
+        val compilationTasks = compilation.compile(moduleRef, Map.empty, layout, globalPolicy, List.empty, pipelining = false)
         val aggregatedTask = Future.sequence(compilationTasks.values.toList).map(CompileResult.merge(_))
         aggregatedTask.andThen{case _ => multiplexer.closeAll()}
         reporter.report(compilation.graph, ManagedConfig().theme, multiplexer)

--- a/src/compile/compile.scala
+++ b/src/compile/compile.scala
@@ -103,7 +103,6 @@ object BloopServer extends Lifecycle.Shutdown {
             log.info("Instantiating a new instance of the Scala compiler")
           case r"The server is listening for incoming connections.*" =>
             log.info(msg"BSP server is listening for incoming connections")
-            multiplexer.start()
           case r"Waiting.*" => None
           case r"Starting thread.*" => None
           case r"Deduplicating compilation of .*" => None
@@ -165,6 +164,7 @@ object BloopServer extends Lifecycle.Shutdown {
       } else None
       val newConnection = Await.result(connect(dir, multiplexer, compilation, targetId, layout, trace = tracePath), Duration.Inf)
       connections += dir -> newConnection
+      multiplexer.start()
       newConnection
     }
 

--- a/src/core/logging.scala
+++ b/src/core/logging.scala
@@ -119,7 +119,7 @@ object Log {
   def log(pid: Pid): Log = new Log(global, pid)
 }
 
-class Log(private[this] val output: LogStyle, pid: Pid) {
+class Log(private[this] val output: LogStyle, val pid: Pid) {
 
   private[this] var writers: List[LogStyle] = List(output)
 


### PR DESCRIPTION
The class `FuryBuildClient` now has no mutable references — all the state related to switching of command line clients is now stored in the global objects `BloopServer` and `Lifecycle`, which serve as a kind of "multiplexer service" for the build clients.

The top of the compilation graph is distorted by the logs of BSP initialization, but I think a better way to fix this would be redrawing the whole graph after those lines of logs.

Fixes #983.