### PR TITLE
Autocompletions on binaries from Maven Central

### DIFF
--- a/etc/install.sh
+++ b/etc/install.sh
@@ -70,7 +70,7 @@ fail() {
 restartFury() {
   message "Checking for currently-active Fury daemon..."
   type -p fury > /dev/null && \
-  fury kill 2> /dev/null && \
+  fury stop 2> /dev/null && \
   message "Starting new version of Fury..." && \
   ${DESTINATION}/bin/fury start
 }

--- a/src/core/args.scala
+++ b/src/core/args.scala
@@ -33,6 +33,7 @@ object Args {
   val AliasArg = CliParam[AliasCmd]('a', 'alias, "specify a command alias")
   val ActionArg = CliParam[String]('A', 'action, "specify a permission action")
   val BinaryArg = CliParam[BinaryId]('b', 'binary, "specify a binary")
+  val PartialBinSpecArg = CliParam[PartialBinSpec]('b', 'binary, "specify a binary")
   val BinaryNameArg = CliParam[BinaryId]('n', 'binary, "specify the name for the binary")
   val BinSpecArg = CliParam[BinSpec]('b', 'binary, "specify a binary dependency")
   val CompilerArg = CliParam[String]('c', 'compiler, "specify a compiler")

--- a/src/model/ids.scala
+++ b/src/model/ids.scala
@@ -471,6 +471,17 @@ object ImportId {
 
 case class ImportId(key: String) extends Key("import")
 
+object PartialBinSpec {
+  implicit val parser: Parser[PartialBinSpec] = unapply(_)
+  def unapply(value: String): Option[PartialBinSpec] = value.only {
+    case r"$g@([^:]+)"                       => PartialBinSpec(g, None, None)
+    case r"$g@([^:]+):$a@([^:]*)"            => PartialBinSpec(g, Some(a), None)
+    case r"$g@([^:]+):$a@([^:]*):$v@([^:]*)" => PartialBinSpec(g, Some(a), Some(v))
+  }
+}
+
+case class PartialBinSpec(group: String, artifact: Option[String], version: Option[String])
+
 object BinaryId {
   implicit val msgShow: MsgShow[BinaryId] = b => UserMsg(_.binary(b.key))
   implicit val stringShow: StringShow[BinaryId] = _.key

--- a/src/module/module.scala
+++ b/src/module/module.scala
@@ -329,9 +329,7 @@ case class BinaryCli(cli: Cli)(implicit log: Log) {
     layout       <- cli.layout
     conf         <- Layer.readFuryConf(layout)
     layer        <- Layer.read(layout, conf)
-    //_            <- ~Log.log(cli.pid).note(cli.peek(PartialBinSpecArg).map(MavenCentral.search(_)).toString)
     binSpecs     <- ~cli.peek(PartialBinSpecArg).to[Set].flatMap(MavenCentral.search(_).toOption.to[Set].flatten)
-    _            <- ~log.note("Binspecs: "+binSpecs)
     cli          <- cli.hint(BinSpecArg, binSpecs)
     schema       <- ~layer.schemas.findBy(SchemaId.default).toOption
     cli          <- cli.hint(ProjectArg, schema.map(_.projects).getOrElse(Nil))

--- a/src/module/module.scala
+++ b/src/module/module.scala
@@ -329,6 +329,10 @@ case class BinaryCli(cli: Cli)(implicit log: Log) {
     layout       <- cli.layout
     conf         <- Layer.readFuryConf(layout)
     layer        <- Layer.read(layout, conf)
+    //_            <- ~Log.log(cli.pid).note(cli.peek(PartialBinSpecArg).map(MavenCentral.search(_)).toString)
+    binSpecs     <- ~cli.peek(PartialBinSpecArg).to[Set].flatMap(MavenCentral.search(_).toOption.to[Set].flatten)
+    _            <- ~log.note("Binspecs: "+binSpecs)
+    cli          <- cli.hint(BinSpecArg, binSpecs)
     schema       <- ~layer.schemas.findBy(SchemaId.default).toOption
     cli          <- cli.hint(ProjectArg, schema.map(_.projects).getOrElse(Nil))
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
@@ -342,7 +346,6 @@ case class BinaryCli(cli: Cli)(implicit log: Log) {
                       module   <- project.modules.findBy(moduleId).toOption
                     } yield module }
 
-    cli        <- cli.hint(BinaryArg)
     cli        <- cli.hint(BinaryNameArg)
     cli        <- cli.hint(BinaryRepoArg, List(RepoId("central")))
     call       <- cli.call()


### PR DESCRIPTION
Fury will now tab-complete binaries from Maven Central. If you type,
```
fury binary add -b com.propensive:<tab>
```
then Fury will suggest `contextual_`, `efflorescence_`, `magnolia_`, `magnolia-examples_` and `mercator_` as partial completions. The next completion will offer a choice of suffices (e.g. `magnolia_2.11:`, `magnolia_2.12:`, `magnolia_2.13:`, and finally it will offer a choice of versions.

It still can't do prefix search on the group ID, so `com.propen<tab>` won't complete to `com.propensive`, unfortunately. I'm not sure if this is possible with the `search.maven.org` API we're using, and the only link I can find to the documentation is broken.