### PR TITLE
Allow a connection to get acquired by multiple sessions at once

### DIFF
--- a/src/compile/compile.scala
+++ b/src/compile/compile.scala
@@ -182,8 +182,8 @@ object BloopServer extends Lifecycle.Shutdown with Lifecycle.ResourceHolder {
     }
 
     Try {
+      acquire(Lifecycle.currentSession, conn)
       conn.synchronized{
-        acquire(Lifecycle.currentSession, conn)
         fn(conn)
       }
     }


### PR DESCRIPTION
Multiple sessions can now subscribe to compile events from the same connection. The execution of  tasks remains synchronized, so only one connection can send compile requests at any time. 

Fixes #987.