### PR TITLE
Added a command to clean Bloop caches for a module.

### DIFF
--- a/src/frontend/menu.scala
+++ b/src/frontend/menu.scala
@@ -48,9 +48,10 @@ object FuryMenu {
       Action('describe, msg"describe the build for a module", BuildCli(_).describe),
       Action('install, msg"install an application locally", BuildCli(_).install)
     ),
-    Menu('clean, msg"clean fury workspace", 'all, needsLayer = false)(
+    Menu('clean, msg"clean fury workspace", 'compiler)(
       Action('all, msg"clean all", CleanCli(_).cleanAll, needsLayer = false),
-      Action('bloop, msg"clean bloop artifacts", CleanCli(_).cleanBloop, needsLayer = false),
+      Action('compiler, msg"clean the caches managed by the compiler", BuildCli(_).clean),
+      Action('targets, msg"clean the compile targets definition files", CleanCli(_).cleanBloop, needsLayer = false),
       Action('classes, msg"clean compiled classes", CleanCli(_).cleanClasses, needsLayer = false),
       Action('logs, msg"clean logs", CleanCli(_).cleanLogs, needsLayer = false),
       Action('repositories, msg"clean repositories", CleanCli(_).cleanRepos, needsLayer = false),


### PR DESCRIPTION
The command `fury clean` now sends a [`buildTarget/cleanCache`](https://github.com/build-server-protocol/build-server-protocol/blob/master/docs/specification.md#clean-cache-request) request to the BSP server. On the other hand, `fury clean all` cleans all temporary files managed by Fury (sources, Bloop project definitions etc.)

Closes #1029.