### PR TITLE
Include the application exit code, if available, into the compilation result

### DIFF
--- a/src/compile/bsp.scala
+++ b/src/compile/bsp.scala
@@ -286,7 +286,7 @@ class FuryBuildServer(layout: Layout, cancel: Cancelator, https: Boolean)(implic
     }
     get(allResults.map{ s =>
       toCompletableFuture(Future.successful {
-        CompileResult.merge(s.toList).bspCompileResult
+        CompileResult.merge(s.toList).asBsp
       })
     })
   }

--- a/src/compile/compile.scala
+++ b/src/compile/compile.scala
@@ -625,8 +625,8 @@ case class Compilation(graph: Target.Graph,
     }.map {
       case compileResult if compileResult.isSuccessful && target.kind.needsExecution =>
         val classDirectories = compileResult.classDirectories
-        val runSuccess = run(target, classDirectories, layout, globalPolicy, args) == 0
-        if(runSuccess) compileResult else compileResult.failed
+        val exitCode = run(target, classDirectories, layout, globalPolicy, args)
+        compileResult.copy(exitCode = Some(exitCode))
       case otherResult =>
         otherResult
     }

--- a/src/core/misc.scala
+++ b/src/core/misc.scala
@@ -17,6 +17,7 @@
 package fury.core
 
 import fury.model._, UiGraph.DiagnosticMessage, fury.io._, fury.ogdl._
+import fury.strings.FuryException
 
 import ch.epfl.scala.bsp4j.{CompileResult => BspCompileResult, _}
 
@@ -55,19 +56,14 @@ case class StartRun(ref: ModuleRef)                              extends Compile
 case class StopRun(ref: ModuleRef)                               extends CompileEvent
 case class DiagnosticMsg(ref: ModuleRef, msg: DiagnosticMessage) extends CompileEvent
 
-case class CompileResult(bspCompileResult: BspCompileResult, scalacOptions: ScalacOptionsResult) {
-  def isSuccessful: Boolean = bspCompileResult.getStatusCode == StatusCode.OK
+case class CompileResult(bspCompileResult: BspCompileResult, scalacOptions: ScalacOptionsResult, exitCode: Option[Int] = None) {
+  def isSuccessful: Boolean = bspCompileResult.getStatusCode == StatusCode.OK && exitCode.forall(_ == 0)
   def classDirectories: Set[Path] = scalacOptions.getItems.asScala.toSet.map { x: ScalacOptionsItem =>
     Path(new URI(x.getClassDirectory))
   }
-  def asTry: Try[CompileResult] = if(isSuccessful) Success(this) else Failure(CompilationFailure())
-  def failed: CompileResult = {
-    val updatedResult = new BspCompileResult(StatusCode.ERROR)
-    updatedResult.setOriginId(bspCompileResult.getOriginId)
-    updatedResult.setDataKind(bspCompileResult.getDataKind)
-    updatedResult.setData(bspCompileResult.getData)
-    copy(bspCompileResult = updatedResult)
-  }
+  def asTry: Try[CompileResult] =
+    if (isSuccessful) Success(this)
+    else Failure(exitCode.fold[FuryException](CompilationFailure())(ExecutionFailure(_)))
 }
 
 object CompileResult {

--- a/src/frontend/recovery.scala
+++ b/src/frontend/recovery.scala
@@ -123,7 +123,9 @@ You can grant these permissions with,
           cli.abort(
               msg"An error occurred while running: ${e.command}${"\n"}${e.stdout}${"\n"}${e.stderr}")
         case e: CompilationFailure =>
-          cli.abort(msg"One of the compile or run tasks failed. Check the logs for details.")
+          cli.abort(msg"One of the compile tasks failed. Check the logs for details.")
+        case ExecutionFailure(exitCode) =>
+          cli.abort(msg"One of the run tasks failed (exit code $exitCode). Check the logs for details.")
         case e: ModuleAlreadyExists =>
           cli.abort(msg"The module '${e.module}' already exists.")
         case e: ProjectAlreadyExists =>

--- a/src/model/exception.scala
+++ b/src/model/exception.scala
@@ -26,6 +26,7 @@ case class CyclesInDependencies(cycle: Set[ModuleRef]) extends FuryException
 case class DnsLookupFailure(domain: String) extends FuryException
 case class DnsResolutionFailure() extends FuryException
 case class DownloadFailure(detail: String) extends FuryException
+case class ExecutionFailure(exitCode: Int) extends FuryException
 case class GraalVMError(message: String) extends FuryException
 case class HistoryMissing() extends FuryException
 case class HistoryCorrupt() extends FuryException

--- a/test/passing/outdated-diagnostics/check
+++ b/test/passing/outdated-diagnostics/check
@@ -26,7 +26,7 @@ Starting compilation of module hello/core
 | not found: value va
 | object Constants { va x = "Hello World!" }
 Compilation of module hello/core failed
-One of the compile or run tasks failed. Check the logs for details.
+One of the compile tasks failed. Check the logs for details.
 1
 Starting compilation of module hello/core
 Successfully compiled module hello/core


### PR DESCRIPTION
```
$ fury -m test-core --output quiet
  2.097 One of the run tasks failed (exit code 1). Check the logs for details.
```

Closes #1070.