### PR TITLE
Improved reporting of errors related to reading layer files.

### DIFF
--- a/src/core/layer.scala
+++ b/src/core/layer.scala
@@ -101,7 +101,7 @@ object Layer {
           Success(FuryUri(dom, loc))
         case r".*\.fury" =>
           val file = Path(path).in(layout.pwd)
-          if(file.exists) Success(FileInput(file)) else Failure(FileNotFound(file))
+          if(file.exists) Success(FileInput(file)) else Failure(LayerNotFound(file))
         case r"([a-z][a-z0-9]*\/)+[a-z][0-9a-z]*([\-.][0-9a-z]+)*" =>
           Success(FuryUri(service, path))
         case name =>

--- a/src/frontend/recovery.scala
+++ b/src/frontend/recovery.scala
@@ -58,7 +58,7 @@ want to make this change to all schemas, please add the --force/-F argument.""")
           cli.abort(msg"Couldn't write to file $path. Cause: ${e.toString}")
         case FileNotFound(path) =>
           cli.abort(
-              msg"""Could not find the file $path. Run `fury layer init` to create a new layer.""")
+              msg"""Could not find the file at $path.""")
         case MissingArg(param) =>
           cli.abort(msg"The parameter $param was not provided.")
         case NoPermissions(perms) =>
@@ -78,6 +78,9 @@ You can grant these permissions with,
           cli.abort(msg"It was not possible to establish a BSP connection")
         case LauncherFailure(msg) =>
           cli.abort(msg"Bloop did not start successfully: $msg")
+        case LayerNotFound(path) =>
+          cli.abort(
+            msg"""Could not find the layer file at $path. Run `fury layer init` to create a new layer.""")
         case DownloadFailure(msg) =>
           cli.abort(msg"Coursier could not complete a download: $msg")
         case DnsResolutionFailure() =>
@@ -97,7 +100,9 @@ You can grant these permissions with,
         case e: InvalidValue =>
           cli.abort(msg"'${e.value}' is not a valid value.")
         case OgdlException(error) =>
-          cli.abort(msg"Failed to read OGDL file: $error.")
+          cli.abort(msg"Failed to read OGDL: $error.")
+        case OgdlReadException(path, e) =>
+          cli.abort(msg"Could not read OGDL from ${path}. Cause: ${e.toString}.")
         case e: ItemNotFound =>
           cli.abort(msg"The ${e.kind} ${e.item} was not found.")
         case e: NotUnique =>

--- a/src/model/exception.scala
+++ b/src/model/exception.scala
@@ -52,6 +52,7 @@ case class InvalidValue(value: String) extends FuryException
 case class NotOnPath(name: ExecName) extends FuryException
 case class LauncherFailure(msg: String) extends FuryException
 case class LayersFailure(layer: ImportPath) extends FuryException
+case class LayerNotFound(path: Path) extends FuryException
 case class MissingCommand() extends FuryException
 case class ModuleAlreadyExists(module: ModuleId) extends FuryException
 case class NoLatestVersion() extends FuryException


### PR DESCRIPTION
There are plenty of different errors that can happen when reading a layer file — invalid format, missing read permissions etc. On the other hand, not all files that can be missing are layer files.