### PR TITLE
Set up a 10 seconds timeout for HTTP requests to the IPFS daemon

### DIFF
--- a/src/core/external.scala
+++ b/src/core/external.scala
@@ -107,7 +107,7 @@ object Ipfs {
   def daemon(env: Environment, quiet: Boolean)(implicit log: Log): Try[IpfsApi] = {
     log.note("Checking for IPFS daemon")
 
-    def getHandle(): Try[IPFS] = Try(new IPFS("localhost", 5001))
+    def getHandle(): Try[IPFS] = Try(new IPFS("localhost", 5001).timeout(10000))
 
     def init(ipfs: Path): Try[Unit] = Xdg.ipfsRepo.ifExists().map(Success(()).waive).getOrElse {
       sh"${ipfs.value} init".exec[Try[String]]().map(_ => ())

--- a/src/core/external.scala
+++ b/src/core/external.scala
@@ -64,6 +64,9 @@ object Ipfs {
             }
             result
         }
+      }.recoverWith {
+        case e: RuntimeException if e.getMessage matches "timeout \\(.+\\) has been exceeded" => Failure(IpfsTimeout())
+        case _: java.net.SocketTimeoutException => Failure(IpfsTimeout())
       }
     }
 

--- a/src/core/http.scala
+++ b/src/core/http.scala
@@ -90,6 +90,8 @@ object Http {
     new URL(url.key).openConnection match {
       case conn: HttpURLConnection =>
         conn.setRequestMethod(method)
+        conn.setConnectTimeout(10000)
+        conn.setReadTimeout(10000)
         
         if(method == "POST" || method == "PUT")
           conn.setRequestProperty("Content-Type", implicitly[Postable[T]].contentType)

--- a/src/frontend/recovery.scala
+++ b/src/frontend/recovery.scala
@@ -99,6 +99,8 @@ You can grant these permissions with,
           cli.abort(msg"The configuration file could not be read.")
         case e: InvalidValue =>
           cli.abort(msg"'${e.value}' is not a valid value.")
+        case e: IpfsTimeout =>
+          cli.abort(msg"An IPFS operation timed out.")
         case OgdlException(error) =>
           cli.abort(msg"Failed to read OGDL: $error.")
         case OgdlReadException(path, e) =>

--- a/src/model/exception.scala
+++ b/src/model/exception.scala
@@ -49,6 +49,7 @@ case class InitFailure() extends FuryException
 case class InvalidKind(expected: Kind) extends FuryException
 case class InvalidLayer(value: String) extends FuryException
 case class InvalidValue(value: String) extends FuryException
+case class IpfsTimeout() extends FuryException
 case class NotOnPath(name: ExecName) extends FuryException
 case class LauncherFailure(msg: String) extends FuryException
 case class LayersFailure(layer: ImportPath) extends FuryException


### PR DESCRIPTION
Fixes #1116.
```
$ fury layer clone -l fury://QmRTBGgmjcmhvaGTh3v7vXdQSCWJgC88CRRg7yCYaMY2v7
 10.063 Could not resolve the hash using IPFS daemon. Cause: java.lang.RuntimeException: timeout (10000 ms) has been exceeded
 10.067 Accessing ipfs.io to retrieve QmRTBGgmjcmhvaGTh3v7vXdQSCWJgC88CRRg7yCYaMY2v7
 20.350 Could not resolve the hash using ipfs.io. Cause: java.net.SocketTimeoutException: Read timed out
 20.354 Accessing gateway.pinata.cloud to retrieve QmRTBGgmjcmhvaGTh3v7vXdQSCWJgC88CRRg7yCYaMY2v7
 30.592 Could not resolve the hash using gateway.pinata.cloud. Cause: java.net.SocketTimeoutException: Read timed out
 30.610 An IPFS operation timed out.
```