### PR TITLE
Display an error when the user attempts to remove a source that does not exist

### DIFF
--- a/src/frontend/recovery.scala
+++ b/src/frontend/recovery.scala
@@ -101,6 +101,8 @@ You can grant these permissions with,
           cli.abort(msg"The configuration file could not be read.")
         case e: InvalidValue =>
           cli.abort(msg"'${e.value}' is not a valid value.")
+        case InvalidSource(source, module) =>
+          cli.abort(msg"Source ${source} is not defined in ${module}.")
         case e: IpfsTimeout =>
           cli.abort(msg"An IPFS operation timed out.")
         case OgdlException(error) =>

--- a/src/model/exception.scala
+++ b/src/model/exception.scala
@@ -50,6 +50,7 @@ case class InitFailure() extends FuryException
 case class InvalidKind(expected: Kind) extends FuryException
 case class InvalidLayer(value: String) extends FuryException
 case class InvalidValue(value: String) extends FuryException
+case class InvalidSource(source: UserMsg, module: ModuleRef) extends FuryException
 case class IpfsTimeout() extends FuryException
 case class NotOnPath(name: ExecName) extends FuryException
 case class NotAuthenticated() extends FuryException

--- a/src/source/source.scala
+++ b/src/source/source.scala
@@ -86,10 +86,10 @@ case class SourceCli(cli: Cli)(implicit log: Log) {
     source      <- call(SourceArg)
     project     <- optProject.asTry
     module      <- optModule.asTry
-    sourceToDel <- ~module.sources.find(_ == source)
+    _           <- if(!module.sources.contains(source)) Failure(InvalidSource(source, module.ref(project))) else Success(())
 
     layer       <- Lenses.updateSchemas(layer)(Lenses.layer.sources(_, project.id,
-                        module.id))(_(_) --= sourceToDel)
+                        module.id))(_(_) -= source)
     
     _           <- Layer.save(layer, layout)
     schema      <- layer.schemas.findBy(SchemaId.default)


### PR DESCRIPTION
Fixes #1148.
```
$ fury source remove -d foo
Source foo//** is not defined in example/core.

```