### PR TITLE
Don't repackage directory entries from dependency JARs into a fat JAR

### DIFF
--- a/src/core/shell.scala
+++ b/src/core/shell.scala
@@ -188,7 +188,7 @@ case class Shell(environment: Environment) {
 
     val creator = new ParallelScatterZipCreator
     val ok = for {
-      _ <- jarInputs.traverse { input => Zipper.pack(new ZipFile(input.javaFile), creator)(!_.getName.contains("META-INF")) }
+      _ <- jarInputs.traverse { input => Zipper.pack(new ZipFile(input.javaFile), creator)(x => !x.getName.contains("META-INF") && !x.isDirectory) }
       _ <- pathInputs.traverse(Zipper.pack(_, creator))
     } yield {
       creator.writeTo(zos)

--- a/test/passing/fat-jar/check
+++ b/test/passing/fat-jar/check
@@ -17,7 +17,7 @@ Starting compilation of module bar/app
 Successfully compiled module bar/app
 Hello World
 Saving JAR file out/bar-app.jar using UTF-8
-Wrote 18.9 MiB to out/bar-app.jar
+Wrote 18.8 MiB to out/bar-app.jar
 0
 bar-app.jar
 scala/math/Ordering$OptionOrdering.class


### PR DESCRIPTION
This should make the duplicate entries in a resulting JAR file much less frequent.

Nevertheless, the problem isn't completely solved, as the dependency JARs might contain _files_ with duplicate names.