### PR TITLE
Improved detection of invalid module ID arguments

### DIFF
--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -323,9 +323,8 @@ case class BuildCli(cli: Cli)(implicit log: Log) {
     optProjectId   <- ~cli.peek(ProjectArg).orElse(moduleRef.map(_.projectId).orElse(schema.main))
     optProject     <- ~optProjectId.flatMap(schema.projects.findBy(_).toOption)
     project        <- optProject.asTry
-    optModuleId   <- ~cli.peek(ModuleArg).orElse(moduleRef.map(_.moduleId).orElse(project.main))
-    optModule      <- ~optModuleId.flatMap(project.modules.findBy(_).toOption)
-    module         <- optModule.asTry
+    moduleId       <- moduleRef.map(~_.moduleId).getOrElse(cli.previewWithDefault(ModuleArg)(project.main))
+    module         <- project.modules.findBy(moduleId)
     pipelining     <- ~call(PipeliningArg).toOption
     fatJar         =  call(FatJarArg).isSuccess
     globalPolicy   <- ~Policy.read(log)

--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -275,7 +275,7 @@ case class BuildCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~cli.peek(ProjectArg).orElse(schema.main)
     optProject   <- ~optProjectId.flatMap(schema.projects.findBy(_).toOption)
     cli          <- cli.hint(ModuleArg, optProject.map(_.modules).getOrElse(Nil))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
     call         <- cli.call()
     project      <- optProject.asTry
     module       <- project.modules.findBy(moduleId)
@@ -322,7 +322,7 @@ case class BuildCli(cli: Cli)(implicit log: Log) {
     optProjectId   <- ~cli.peek(ProjectArg).orElse(moduleRef.map(_.projectId).orElse(schema.main))
     optProject     <- ~optProjectId.flatMap(schema.projects.findBy(_).toOption)
     project        <- optProject.asTry
-    moduleId       <- moduleRef.map(~_.moduleId).getOrElse(cli.previewWithDefault(ModuleArg)(project.main))
+    moduleId       <- moduleRef.map(~_.moduleId).getOrElse(cli.preview(ModuleArg)(project.main))
     module         <- project.modules.findBy(moduleId)
     pipelining     <- ~call(PipeliningArg).toOption
     fatJar         =  call(FatJarArg).isSuccess
@@ -422,7 +422,7 @@ case class BuildCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~cli.peek(ProjectArg).orElse(schema.main)
     optProject   <- ~optProjectId.flatMap(schema.projects.findBy(_).toOption)
     cli          <- cli.hint(ModuleArg, optProject.map(_.modules).getOrElse(Nil))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
     call         <- cli.call()
     https        <- ~call(HttpsArg).isSuccess
     noSecurity   <- ~call(NoSecurityArg).isSuccess
@@ -451,7 +451,7 @@ case class BuildCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~cli.peek(ProjectArg).orElse(schema.main)
     optProject   <- ~optProjectId.flatMap(schema.projects.findBy(_).toOption)
     cli          <- cli.hint(ModuleArg, optProject.map(_.modules).getOrElse(Nil))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
     cli          <- cli.hint(SingleColumnArg)
     call         <- cli.call()
     https        <- ~call(HttpsArg).isSuccess
@@ -482,7 +482,7 @@ case class BuildCli(cli: Cli)(implicit log: Log) {
     cli          <- cli.hint(ModuleArg, optProject.map(_.modules).getOrElse(Nil))
     call         <- cli.call()
     https        <- ~call(HttpsArg).isSuccess
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
     project      <- optProject.asTry
     module       <- project.modules.findBy(moduleId)
 

--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -275,11 +275,10 @@ case class BuildCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~cli.peek(ProjectArg).orElse(schema.main)
     optProject   <- ~optProjectId.flatMap(schema.projects.findBy(_).toOption)
     cli          <- cli.hint(ModuleArg, optProject.map(_.modules).getOrElse(Nil))
-    optModuleId  <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
-    optModule    <- ~optModuleId.flatMap { arg => optProject.flatMap(_.modules.findBy(arg).toOption) }
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
     call         <- cli.call()
     project      <- optProject.asTry
-    module       <- optModule.asTry
+    module       <- project.modules.findBy(moduleId)
     moduleRef    =  module.ref(project)
 
     compilation  <- Compilation.syncCompilation(schema, moduleRef, layout, https = false, noSecurity = true)
@@ -423,13 +422,12 @@ case class BuildCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~cli.peek(ProjectArg).orElse(schema.main)
     optProject   <- ~optProjectId.flatMap(schema.projects.findBy(_).toOption)
     cli          <- cli.hint(ModuleArg, optProject.map(_.modules).getOrElse(Nil))
-    optModuleId  <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
-    optModule    <- ~optModuleId.flatMap { arg => optProject.flatMap(_.modules.findBy(arg).toOption) }
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
     call         <- cli.call()
     https        <- ~call(HttpsArg).isSuccess
     noSecurity   <- ~call(NoSecurityArg).isSuccess
     project      <- optProject.asTry
-    module       <- optModule.asTry
+    module       <- project.modules.findBy(moduleId)
     
     compilation  <- Compilation.syncCompilation(schema, module.ref(project), layout,
                         https, noSecurity)
@@ -453,14 +451,13 @@ case class BuildCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~cli.peek(ProjectArg).orElse(schema.main)
     optProject   <- ~optProjectId.flatMap(schema.projects.findBy(_).toOption)
     cli          <- cli.hint(ModuleArg, optProject.map(_.modules).getOrElse(Nil))
-    optModuleId  <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
-    optModule    <- ~optModuleId.flatMap { arg => optProject.flatMap(_.modules.findBy(arg).toOption) }
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
     cli          <- cli.hint(SingleColumnArg)
     call         <- cli.call()
     https        <- ~call(HttpsArg).isSuccess
     singleColumn <- ~call(SingleColumnArg).isSuccess
     project      <- optProject.asTry
-    module       <- optModule.asTry
+    module       <- project.modules.findBy(moduleId)
     
     compilation  <- Compilation.syncCompilation(schema, module.ref(project), layout,
                         https, false)
@@ -485,10 +482,9 @@ case class BuildCli(cli: Cli)(implicit log: Log) {
     cli          <- cli.hint(ModuleArg, optProject.map(_.modules).getOrElse(Nil))
     call         <- cli.call()
     https        <- ~call(HttpsArg).isSuccess
-    optModuleId  <- ~call(ModuleArg).toOption.orElse(optProject.flatMap(_.main))
-    optModule    <- ~optModuleId.flatMap { arg => optProject.flatMap(_.modules.findBy(arg).toOption) }
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
     project      <- optProject.asTry
-    module       <- optModule.asTry
+    module       <- project.modules.findBy(moduleId)
 
     compilation  <- Compilation.syncCompilation(schema, module.ref(project), layout,
                         https, false)

--- a/src/core/cli.scala
+++ b/src/core/cli.scala
@@ -175,10 +175,11 @@ class Cli(val stdout: java.io.PrintWriter,
 
   def peek(param: CliParam): Option[param.Type] = args.get(param.param).toOption
   def preview(param: CliParam): Try[param.Type] = args.get(param.param)
-  def previewWithDefault(param: CliParam)(default: Option[param.Type]): Try[Option[param.Type]] = {
-    preview(param).map(Some(_)).recover {
-        case e: exoskeleton.MissingArg => default
-    }
+  def previewWithDefault(param: CliParam)(default: Option[param.Type]): Try[param.Type] = {
+    val result = preview(param)
+    if(default.isDefined) result.recover {
+        case _: exoskeleton.MissingArg => default.get
+    } else result
   }
 
   def pwd: Try[Path] = env.workDir.ascribe(FileNotFound(Path("/"))).map(Path(_))

--- a/src/core/cli.scala
+++ b/src/core/cli.scala
@@ -174,9 +174,8 @@ class Cli(val stdout: java.io.PrintWriter,
   def action(blk: Call => Try[ExitStatus])(implicit log: Log): Try[ExitStatus] = call().flatMap(blk)
 
   def peek(param: CliParam): Option[param.Type] = args.get(param.param).toOption
-  def preview(param: CliParam): Try[param.Type] = args.get(param.param)
-  def previewWithDefault(param: CliParam)(default: Option[param.Type]): Try[param.Type] = {
-    val result = preview(param)
+  def preview(param: CliParam)(default: Option[param.Type] = None): Try[param.Type] = {
+    val result = args.get(param.param)
     if(default.isDefined) result.recover {
         case _: exoskeleton.MissingArg => default.get
     } else result

--- a/src/dependency/dependency.scala
+++ b/src/dependency/dependency.scala
@@ -37,13 +37,12 @@ case class DependencyCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId  <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule    <- Success { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+    optModule    =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     cli     <- cli.hint(RawArg)
     table   <- ~Tables().dependencies
@@ -72,13 +71,12 @@ case class DependencyCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId  <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule    <- Success { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+    optModule    =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     cli       <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
     cli       <- cli.hint(LinkArg, optModule.to[List].flatMap(_.dependencies.to[List]))
@@ -113,13 +111,12 @@ case class DependencyCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId  <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule    <- Success { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+    optModule    =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     optSchema       <- ~layer.mainSchema.toOption
     importedSchemas  = optSchema.flatMap(_.importedSchemas(layout, false).toOption)
@@ -156,12 +153,12 @@ case class EnvCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId  <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
-    optModule    <- Success { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+
+    optModule    =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
     cli          <- cli.hint(RawArg)
     table        <- ~Tables().envs
     cli          <- cli.hint(ColumnArg, table.headings.map(_.name.toLowerCase))
@@ -188,13 +185,12 @@ case class EnvCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId  <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule    <- Success { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+    optModule    =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
     cli          <- cli.hint(EnvArg, optModule.to[List].flatMap(_.environment.to[List]))
@@ -222,13 +218,12 @@ case class EnvCli(cli: Cli)(implicit log: Log) {
     optProjectId    <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject      <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli             <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId     <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId        <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule       <- Success { for {
-                         project  <- optProject
-                         moduleId <- optModuleId
-                         module   <- project.modules.findBy(moduleId).toOption
-                       } yield module }
+    optModule       =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
     optSchema       <- ~layer.mainSchema.toOption
 
     importedSchemas  = optSchema.flatMap(_.importedSchemas(layout, false).toOption)
@@ -259,13 +254,12 @@ case class PermissionCli(cli: Cli)(implicit log: Log) {
     optProjectId    <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject      <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli             <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId     <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId        <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule       <- Success { for {
-                         project  <- optProject
-                         moduleId <- optModuleId
-                         module   <- project.modules.findBy(moduleId).toOption
-                       } yield module }
+    optModule       =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     cli             <- cli.hint(ScopeArg, ScopeId.All)
     cli             <- cli.hint(NoGrantArg)
@@ -302,13 +296,12 @@ case class PermissionCli(cli: Cli)(implicit log: Log) {
     optProjectId  <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject    <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli           <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId   <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId      <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule     <- Success { for {
-                       project  <- optProject
-                       moduleId <- optModuleId
-                       module   <- project.modules.findBy(moduleId).toOption
-                     } yield module }
+    optModule     =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     cli           <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
     cli           <- cli.hint(PermissionArg, optModule.to[List].flatMap(_.policyEntries))
@@ -338,13 +331,12 @@ case class PermissionCli(cli: Cli)(implicit log: Log) {
     optProjectId  <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject    <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli           <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId   <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId      <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule     <- Success { for {
-                       project  <- optProject
-                       moduleId <- optModuleId
-                       module   <- project.modules.findBy(moduleId).toOption
-                     } yield module }
+    optModule     =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
     
     cli           <- cli.hint(RawArg)
     table         <- ~Tables().permissions
@@ -370,13 +362,12 @@ case class PermissionCli(cli: Cli)(implicit log: Log) {
     optProjectId  <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject    <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli           <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId   <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId      <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule     <- Success { for {
-                       project  <- optProject
-                       moduleId <- optModuleId
-                       module   <- project.modules.findBy(moduleId).toOption
-                     } yield module }
+    optModule     =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
     cli           <- cli.hint(ScopeArg, ScopeId.All)
     
     //TODO check if hints still work
@@ -408,13 +399,12 @@ case class PropertyCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId  <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId      <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule    =  { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+    optModule     =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     cli     <- cli.hint(RawArg)
     table   <- ~Tables().props
@@ -442,13 +432,12 @@ case class PropertyCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId  <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId      <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule    =  { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+    optModule     =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     cli       <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
     cli       <- cli.hint(PropArg, optModule.to[List].flatMap(_.properties.to[List]))
@@ -475,13 +464,12 @@ case class PropertyCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId  <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId      <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule    <- Success { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+    optModule     =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     layout       <- cli.layout
     conf         <- Layer.readFuryConf(layout)
@@ -492,13 +480,12 @@ case class PropertyCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId  <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId      <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule    =  { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+    optModule     =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     optSchema       <- ~layer.mainSchema.toOption
     importedSchemas  = optSchema.flatMap(_.importedSchemas(layout, false).toOption)

--- a/src/dependency/dependency.scala
+++ b/src/dependency/dependency.scala
@@ -37,7 +37,7 @@ case class DependencyCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule    =  (for {
       project  <- optProject
@@ -71,7 +71,7 @@ case class DependencyCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule    =  (for {
       project  <- optProject
@@ -111,7 +111,7 @@ case class DependencyCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule    =  (for {
       project  <- optProject
@@ -153,7 +153,7 @@ case class EnvCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule    =  (for {
       project  <- optProject
@@ -185,7 +185,7 @@ case class EnvCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule    =  (for {
       project  <- optProject
@@ -218,7 +218,7 @@ case class EnvCli(cli: Cli)(implicit log: Log) {
     optProjectId    <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject      <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli             <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId        <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId        <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule       =  (for {
       project  <- optProject
@@ -254,7 +254,7 @@ case class PermissionCli(cli: Cli)(implicit log: Log) {
     optProjectId    <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject      <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli             <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId        <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId        <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule       =  (for {
       project  <- optProject
@@ -296,7 +296,7 @@ case class PermissionCli(cli: Cli)(implicit log: Log) {
     optProjectId  <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject    <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli           <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId      <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId      <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule     =  (for {
       project  <- optProject
@@ -331,7 +331,7 @@ case class PermissionCli(cli: Cli)(implicit log: Log) {
     optProjectId  <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject    <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli           <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId      <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId      <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule     =  (for {
       project  <- optProject
@@ -362,7 +362,7 @@ case class PermissionCli(cli: Cli)(implicit log: Log) {
     optProjectId  <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject    <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli           <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId      <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId      <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule     =  (for {
       project  <- optProject
@@ -399,7 +399,7 @@ case class PropertyCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId      <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId      <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule     =  (for {
       project  <- optProject
@@ -432,7 +432,7 @@ case class PropertyCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId      <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId      <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule     =  (for {
       project  <- optProject
@@ -464,7 +464,7 @@ case class PropertyCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId      <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId      <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule     =  (for {
       project  <- optProject
@@ -480,7 +480,7 @@ case class PropertyCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId      <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId      <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule     =  (for {
       project  <- optProject

--- a/src/module/module.scala
+++ b/src/module/module.scala
@@ -173,7 +173,7 @@ case class ModuleCli(cli: Cli)(implicit log: Log) {
     schema      <- layer.schemas.findBy(SchemaId.default)
     cli         <- cli.hint(CompilerArg, ModuleRef.JavaRef :: schema.compilerRefs(layout, true))
     cli         <- cli.hint(KindArg, Kind.all)
-    optModuleId =  cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main)).toOption
+    optModuleId =  cli.preview(ModuleArg)(optProject.flatMap(_.main)).toOption
 
     optModule   <- Success { for {
                       project  <- optProject
@@ -243,7 +243,7 @@ case class BinaryCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule    =  (for {
       project  <- optProject
@@ -275,7 +275,7 @@ case class BinaryCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli         <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule    =  (for {
       project  <- optProject
@@ -309,7 +309,7 @@ case class BinaryCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule    = (for {
                       project  <- optProject
@@ -342,7 +342,7 @@ case class BinaryCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
     cli          <- cli.hint(BinaryNameArg)
     cli          <- cli.hint(BinaryRepoArg, List(RepoId("central")))
     call         <- cli.call()
@@ -373,7 +373,7 @@ case class OptionCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli         <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule    =  (for {
       project  <- optProject
@@ -409,7 +409,7 @@ case class OptionCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli         <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule    =  (for {
       project  <- optProject
@@ -443,7 +443,7 @@ case class OptionCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli         <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule    =  (for {
       project  <- optProject
@@ -478,7 +478,7 @@ case class OptionCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli         <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule    =  (for {
       project  <- optProject
@@ -507,7 +507,7 @@ case class OptionCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli         <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule    =  (for {
       project  <- optProject

--- a/src/module/module.scala
+++ b/src/module/module.scala
@@ -173,7 +173,7 @@ case class ModuleCli(cli: Cli)(implicit log: Log) {
     schema      <- layer.schemas.findBy(SchemaId.default)
     cli         <- cli.hint(CompilerArg, ModuleRef.JavaRef :: schema.compilerRefs(layout, true))
     cli         <- cli.hint(KindArg, Kind.all)
-    optModuleId <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    optModuleId =  cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main)).toOption
 
     optModule   <- Success { for {
                       project  <- optProject
@@ -242,14 +242,13 @@ case class BinaryCli(cli: Cli)(implicit log: Log) {
     cli          <- cli.hint(ProjectArg, schema.map(_.projects).getOrElse(Nil))
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
-    cli         <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule   <- Success { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+    optModule    =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     cli         <- cli.hint(RawArg)
     table       <- ~Tables().binaries
@@ -276,13 +275,12 @@ case class BinaryCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli         <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule   <- Success { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+    optModule    =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     cli         <- cli.hint(BinaryArg, optModule.to[List].flatMap(_.binaries.map(_.id)))
     cli         <- cli.hint(VersionArg)
@@ -310,14 +308,13 @@ case class BinaryCli(cli: Cli)(implicit log: Log) {
     cli          <- cli.hint(ProjectArg, schema.map(_.projects).getOrElse(Nil))
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
-    cli         <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule   <- Success { for {
+    optModule    = (for {
                       project  <- optProject
-                      moduleId <- optModuleId
                       module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+                    } yield module)
 
     cli         <- cli.hint(BinaryArg, optModule.to[List].flatMap(_.binaries.map(_.id)))
     call        <- cli.call()
@@ -344,20 +341,13 @@ case class BinaryCli(cli: Cli)(implicit log: Log) {
     cli          <- cli.hint(ProjectArg, schema.map(_.projects).getOrElse(Nil))
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
-    cli         <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
-
-    optModule   <- Success { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
-
-    cli        <- cli.hint(BinaryNameArg)
-    cli        <- cli.hint(BinaryRepoArg, List(RepoId("central")))
-    call       <- cli.call()
+    cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    cli          <- cli.hint(BinaryNameArg)
+    cli          <- cli.hint(BinaryRepoArg, List(RepoId("central")))
+    call         <- cli.call()
     project    <- optProject.asTry
-    module     <- optModule.asTry
+    module     <- project.modules.findBy(moduleId)
     binSpecArg <- call(BinSpecArg)
     binName    <- ~call(BinaryNameArg).toOption
     repoId     <- ~call(BinaryRepoArg).getOrElse(BinRepoId.Central)
@@ -383,13 +373,12 @@ case class OptionCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli         <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule   <- Success { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+    optModule    =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     cli         <- cli.hint(RawArg)
     table       <- ~Tables().opts
@@ -420,13 +409,12 @@ case class OptionCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli         <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule   <- Success { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+    optModule    =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     cli      <- cli.hint(OptArg, optModule.to[List].flatMap(_.opts))
     cli      <- cli.hint(PersistentArg)
@@ -455,13 +443,12 @@ case class OptionCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli         <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule   <- Success { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+    optModule    =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     cli         <- cli.hint(OptArg)
     cli         <- cli.hint(DescriptionArg)
@@ -491,13 +478,12 @@ case class OptionCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli         <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule   <- Success { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+    optModule    =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     cli         <- cli.hint(OptArg)
     call        <- cli.call()
@@ -521,13 +507,12 @@ case class OptionCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli         <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
 
-    optModule   <- Success { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+    optModule    =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     optDefs  <- ~(for {
                   project     <- optProject

--- a/src/source/source.scala
+++ b/src/source/source.scala
@@ -39,7 +39,7 @@ case class SourceCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
     
     optModule    =  (for {
                       project  <- optProject
@@ -72,7 +72,7 @@ case class SourceCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule    =  (for {
       project  <- optProject
@@ -104,7 +104,7 @@ case class SourceCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+    moduleId     <- cli.preview(ModuleArg)(optProject.flatMap(_.main))
 
     optModule    =  (for {
       project  <- optProject
@@ -150,9 +150,9 @@ case class FrontEnd(cli: Cli)(implicit log: Log) {
   lazy val layer: Try[Layer] = (layout, conf) >>= Layer.read
   lazy val schema: Try[Schema] = layer >>= (_.schemas.findBy(SchemaId.default))
 
-  lazy val projectId: Try[ProjectId] = schema >>= (cli.preview(ProjectArg) orElse _.main.asTry)
+  lazy val projectId: Try[ProjectId] = schema >>= (cli.preview(ProjectArg)() orElse _.main.asTry)
   lazy val project: Try[Project] = (schema, projectId) >>= (_.projects.findBy(_))
-  lazy val moduleId: Try[ModuleId] = project >>= (cli.preview(ModuleArg) orElse _.main.asTry)
+  lazy val moduleId: Try[ModuleId] = project >>= (cli.preview(ModuleArg)() orElse _.main.asTry)
   lazy val module: Try[Module] = (project, moduleId) >>= (_.modules.findBy(_))
 
   implicit val projectHints: ProjectArg.Hinter = ProjectArg.hint(schema >> (_.projects.map(_.id)))
@@ -167,7 +167,7 @@ case class FrontEnd(cli: Cli)(implicit log: Log) {
   def resourcesLens(projectId: ProjectId, moduleId: ModuleId) =
     Lens[Layer](_.schemas(on(SchemaId.default)).projects(on(projectId)).modules(on(moduleId)).resources)
 
-  lazy val resource: Try[Source] = cli.preview(SourceArg)
+  lazy val resource: Try[Source] = cli.preview(SourceArg)()
 
   
 

--- a/src/source/source.scala
+++ b/src/source/source.scala
@@ -39,13 +39,12 @@ case class SourceCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId  <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
     
-    optModule    <- Success { for {
+    optModule    =  (for {
                       project  <- optProject
-                      moduleId <- optModuleId
                       module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+                    } yield module)
 
     cli     <- cli.hint(RawArg)
     table   <- ~Tables().sources
@@ -73,13 +72,12 @@ case class SourceCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId  <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
-    
-    optModule    <- Success { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+
+    optModule    =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     cli         <- cli.hint(SourceArg, optModule.to[List].flatMap(_.sources).map(_.dir))
     call        <- cli.call()
@@ -106,13 +104,12 @@ case class SourceCli(cli: Cli)(implicit log: Log) {
     optProjectId <- ~schema.flatMap { s => cli.peek(ProjectArg).orElse(s.main) }
     optProject   <- ~schema.flatMap { s => optProjectId.flatMap(s.projects.findBy(_).toOption) }
     cli          <- cli.hint(ModuleArg, optProject.to[List].flatMap(_.modules))
-    optModuleId  <- ~cli.peek(ModuleArg).orElse(optProject.flatMap(_.main))
-    
-    optModule    <- Success { for {
-                      project  <- optProject
-                      moduleId <- optModuleId
-                      module   <- project.modules.findBy(moduleId).toOption
-                    } yield module }
+    moduleId     <- cli.previewWithDefault(ModuleArg)(optProject.flatMap(_.main))
+
+    optModule    =  (for {
+      project  <- optProject
+      module   <- project.modules.findBy(moduleId).toOption
+    } yield module)
 
     schema     <- layer.schemas.findBy(SchemaId.default)
 


### PR DESCRIPTION
```
$ fury -m foo
The module foo was not found.
$ fury -m foo-bar
The module foo-bar was not found.
$ fury -m foo/bar
The argument 'foo/bar' was not a valid value for the parameter '-m/--module'.
```
This pull request is related to #1088, but it doesn't fix the issue completely.