### PR TITLE
Fixes and tests for OGDL serialization of collections

### DIFF
--- a/src/core/source.scala
+++ b/src/core/source.scala
@@ -29,6 +29,7 @@ object Source {
   implicit val ogdlReader: OgdlReader[Source] = src => unapply(src.id()).get // FIXME
   implicit val ogdlWriter: OgdlWriter[Source] = src => Ogdl(Vector("id" -> Ogdl(src.key)))
   implicit val parser: Parser[Source] = unapply(_)
+  implicit val index: Index[Source] = FieldIndex("id")
   implicit val keyName: KeyName[Source] = () => msg"source"
 
   implicit val sourceDiff: Diff[Source] =

--- a/src/model/ids.scala
+++ b/src/model/ids.scala
@@ -450,7 +450,7 @@ sealed abstract class ScopeId(val id: String) extends scala.Product with scala.S
 object Grant {
   implicit val ord: Ordering[Grant] = Ordering[String].on[Grant](_.permission.hash)
   implicit val stringShow: StringShow[Grant] = _.digest[Sha256].encoded
-  implicit val index: Index[Grant] = Index("permission")
+  implicit val index: Index[Grant] = FieldIndex("permission")
 }
 
 case class Grant(scope: Scope, permission: Permission)

--- a/src/ogdl-test/testreader.scala
+++ b/src/ogdl-test/testreader.scala
@@ -1,0 +1,92 @@
+/*
+
+    Fury, version 0.12.3. Copyright 2018-20 Jon Pretty, Propensive OÜ.
+
+    The primary distribution site is: https://propensive.com/
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+    compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License is
+    distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and limitations under the License.
+
+*/
+package fury.ogdl
+
+import probably._
+
+import scala.collection.immutable.{SortedSet, TreeSet}
+import scala.language.implicitConversions
+import scala.util.{Try, Success}
+
+object OgdlReaderTest extends TestApp {
+  private[this] val empty = Ogdl(Vector())
+
+  private[this] case class Foo(bar: String, baz: Int)
+  private[this] implicit val ord: Ordering[Foo] = Ordering[Int].on[Foo](_.baz)
+
+  private[this] case class Quux(handle: String, data: SortedSet[String])
+
+  override def tests(): Unit = {
+    test("string") {
+      val ogdl = Ogdl(Vector(("Hello World!", empty)))
+      Try(implicitly[OgdlReader[String]].read(ogdl))
+    }.assert(_ == Success("Hello World!"))
+
+    test("option") {
+      val ogdl = Ogdl(Vector(("Some",Ogdl(Vector(("false",empty))))))
+      Try(implicitly[OgdlReader[Option[Boolean]]].read(ogdl))
+    }.assert(_ == Success(Some(false)))
+
+    test("case class") {
+      val ogdl = Ogdl(Vector(
+        ("bar",Ogdl(Vector(("1", empty)))),
+        ("baz",Ogdl(Vector(("2", empty))))
+      ))
+      Try(implicitly[OgdlReader[Foo]].read(ogdl))
+    }.assert(_ == Success( Foo(bar = "1", baz = 2)))
+
+    test("list of strings") {
+      val ogdl = Ogdl(Vector(("3",Ogdl(Vector(("3",empty)))), ("2",Ogdl(Vector(("2",empty)))), ("1",Ogdl(Vector(("1",empty))))))
+      val x = Try(implicitly[OgdlReader[List[String]]].read(ogdl))
+      println(x)
+      x
+    }.assert(_ == Success(List("3", "2", "1")))
+
+    test("sorted set of integers") {
+      val ogdl = Ogdl(Vector(("1",Ogdl(Vector(("1",empty)))), ("2",Ogdl(Vector(("2",empty)))), ("3",Ogdl(Vector(("3",empty))))))
+      Try(implicitly[OgdlReader[SortedSet[Int]]].read(ogdl))
+    }.assert(_ == Success(TreeSet(1, 2, 3)))
+
+    test("sorted set of case classes") {
+      implicit val index: Index[Foo] = Index("bar")
+      val ogdl = Ogdl(Vector(
+        ("B",Ogdl(Vector(("baz",Ogdl(Vector(("1",empty))))))),
+        ("A",Ogdl(Vector(("baz",Ogdl(Vector(("2",empty))))))),
+        ("B",Ogdl(Vector(("baz",Ogdl(Vector(("3",empty)))))))
+      ))
+      val x = Try(implicitly[OgdlReader[SortedSet[Foo]]].read(ogdl))
+      println(x)
+      x
+    }.assert(_ == Success(TreeSet(Foo(bar = "B", baz = 1), Foo(bar = "A", baz = 2), Foo(bar = "B", baz = 3))))
+
+    test("case class with a sorted set") {
+      implicit val index: Index[Quux] = Index("handle")
+      val ogdl = Ogdl(Vector(
+        ("handle",Ogdl(Vector(("Q",empty)))),
+        ("data",Ogdl(Vector(
+          ("A",Ogdl(Vector(("A",empty)))),
+          ("B",Ogdl(Vector(("B",empty)))),
+          ("C",Ogdl(Vector(("C",empty))))
+        )))
+      ))
+      val x = Try(implicitly[OgdlReader[Quux]].read(ogdl))
+      println(x)
+      x
+    }.assert(_ == Success(Quux("Q", TreeSet("A", "B", "C"))))
+
+  }
+}

--- a/src/ogdl-test/testreader.scala
+++ b/src/ogdl-test/testreader.scala
@@ -53,12 +53,12 @@ object OgdlReaderTest extends TestApp {
     }.assert(_ == Success( Foo(bar = "1", baz = 2)))
 
     test("list of strings") {
-      val ogdl = Ogdl(Vector(("3",Ogdl(Vector(("3",empty)))), ("2",Ogdl(Vector(("2",empty)))), ("1",Ogdl(Vector(("1",empty))))))
-     Try(implicitly[OgdlReader[List[String]]].read(ogdl))
-    }.assert(_ == Success(List("3", "2", "1")))
+      val ogdl = Ogdl(Vector(("foo", Ogdl(Vector(("bar", Ogdl(Vector(("baz", empty)))))))))
+      Try(implicitly[OgdlReader[List[String]]].read(ogdl))
+    }.assert(_ == Success(List("foo", "bar", "baz")))
 
     test("sorted set of integers") {
-      val ogdl = Ogdl(Vector(("1",Ogdl(Vector(("1",empty)))), ("2",Ogdl(Vector(("2",empty)))), ("3",Ogdl(Vector(("3",empty))))))
+      val ogdl = Ogdl(Vector(("1", Ogdl(Vector(("2", Ogdl(Vector(("3", empty)))))))))
       Try(implicitly[OgdlReader[SortedSet[Int]]].read(ogdl))
     }.assert(_ == Success(TreeSet(1, 2, 3)))
 
@@ -76,11 +76,7 @@ object OgdlReaderTest extends TestApp {
       implicit val index: Index[Quux] = FieldIndex("handle")
       val ogdl = Ogdl(Vector(
         ("handle",Ogdl(Vector(("Q",empty)))),
-        ("data",Ogdl(Vector(
-          ("A",Ogdl(Vector(("A",empty)))),
-          ("B",Ogdl(Vector(("B",empty)))),
-          ("C",Ogdl(Vector(("C",empty))))
-        )))
+        ("data",Ogdl(Vector(("A", Ogdl(Vector(("B", Ogdl(Vector(("C", empty))))))))))
       ))
       Try(implicitly[OgdlReader[Quux]].read(ogdl))
     }.assert(_ == Success(Quux("Q", TreeSet("A", "B", "C"))))

--- a/src/ogdl-test/testreader.scala
+++ b/src/ogdl-test/testreader.scala
@@ -62,7 +62,7 @@ object OgdlReaderTest extends TestApp {
     }.assert(_ == Success(TreeSet(1, 2, 3)))
 
     test("sorted set of case classes") {
-      implicit val index: Index[Foo] = Index("bar")
+      implicit val index: Index[Foo] = FieldIndex("bar")
       val ogdl = Ogdl(Vector(
         ("B",Ogdl(Vector(("baz",Ogdl(Vector(("1",empty))))))),
         ("A",Ogdl(Vector(("baz",Ogdl(Vector(("2",empty))))))),
@@ -74,7 +74,7 @@ object OgdlReaderTest extends TestApp {
     }.assert(_ == Success(TreeSet(Foo(bar = "B", baz = 1), Foo(bar = "A", baz = 2), Foo(bar = "B", baz = 3))))
 
     test("case class with a sorted set") {
-      implicit val index: Index[Quux] = Index("handle")
+      implicit val index: Index[Quux] = FieldIndex("handle")
       val ogdl = Ogdl(Vector(
         ("handle",Ogdl(Vector(("Q",empty)))),
         ("data",Ogdl(Vector(

--- a/src/ogdl-test/tests.scala
+++ b/src/ogdl-test/tests.scala
@@ -16,13 +16,15 @@
 */
 package fury
 
-import fury.ogdl.{OgdlParserTest, OgdlSerializerTest}
+import fury.ogdl.{OgdlParserTest, OgdlReaderTest, OgdlSerializerTest, OgdlWriterTest}
 import probably.TestApp
 
 object Tests {
   private val testSuites = List[TestApp](
       OgdlParserTest,
-      OgdlSerializerTest
+      OgdlSerializerTest,
+      OgdlWriterTest,
+      OgdlReaderTest
   )
 
   def main(args: Array[String]): Unit = testSuites.map(_.execute()).find(_.value != 0).foreach(_.exit())

--- a/src/ogdl-test/testwriter.scala
+++ b/src/ogdl-test/testwriter.scala
@@ -66,9 +66,7 @@ object OgdlWriterTest extends TestApp {
 
     test("list of strings") {
       val input = List("3", "2", "1")
-      val x = Try{Ogdl(input)}
-      println(x)
-      x
+      Try{Ogdl(input)}
     }.assert(_ == Success(
       Ogdl(Vector(
         ("3",Ogdl(Vector(("3",empty)))),
@@ -79,9 +77,7 @@ object OgdlWriterTest extends TestApp {
 
     test("sorted set of integers") {
       val input: SortedSet[Int] = TreeSet(1, 2, 3)
-      val x = Try{Ogdl(input)}
-      println(x)
-      x
+      Try{Ogdl(input)}
     }.assert(_ == Success(Ogdl(Vector(
       ("1",Ogdl(Vector(("1",empty)))),
       ("2",Ogdl(Vector(("2",empty)))),
@@ -89,32 +85,49 @@ object OgdlWriterTest extends TestApp {
     ))))
 
     test("sorted set of case classes") {
-      implicit val index: Index[Foo] = Index("bar")
+      implicit val index: Index[Foo] = FieldIndex("bar")
       val input: SortedSet[Foo] = TreeSet(Foo(bar = "A", baz = 2), Foo(bar = "B", baz = 3), Foo(bar = "B", baz = 1))
       Try{Ogdl(input)}
+      //TODO think of a more compact format
     }.assert(_ == Success(Ogdl(Vector(
-      ("B",Ogdl(Vector(("baz",Ogdl(Vector(("1",empty))))))),
-      ("A",Ogdl(Vector(("baz",Ogdl(Vector(("2",empty))))))),
-      ("B",Ogdl(Vector(("baz",Ogdl(Vector(("3",empty)))))))
+      ("kvp",Ogdl(Vector(("key",Ogdl(Vector(("B",empty)))), ("value",Ogdl(Vector(("baz",Ogdl(Vector(("1",empty)))))))))),
+      ("kvp",Ogdl(Vector(("key",Ogdl(Vector(("A",empty)))), ("value",Ogdl(Vector(("baz",Ogdl(Vector(("2",empty)))))))))),
+      ("kvp",Ogdl(Vector(("key",Ogdl(Vector(("B",empty)))), ("value",Ogdl(Vector(("baz",Ogdl(Vector(("3",empty))))))))))
     ))))
 
-    test("sorted set of case classes 2") {
-      implicit val index: Index[Foo2] = Index("bar")
-      val input: SortedSet[Foo2] = TreeSet(Foo2(bar = Some("A"), baz = 2), Foo2(bar = Some("B"), baz = 3), Foo2(bar = None, baz = 1))
+    test("sorted set of case classes with complex index") {
+      implicit val index: Index[Foo2] = FieldIndex("bar")
+      val input: SortedSet[Foo2] = TreeSet(
+        Foo2(bar = Some("A"), baz = 2),
+        Foo2(bar = Some("B"), baz = 3),
+        Foo2(bar = None, baz = 1),
+        Foo2(bar = None, baz = 4)
+      )
+      //FIXME Uniqueness of the index field is not quaranteed
       Try{Ogdl(input)}
-      //FIXME value of the option is lost
     }.assert(_ == Success(Ogdl(Vector(
-      ("None",Ogdl(Vector(("baz",Ogdl(Vector(("1",empty))))))),
-      ("Some",Ogdl(Vector(("baz",Ogdl(Vector(("2",empty))))))),
-      ("Some",Ogdl(Vector(("baz",Ogdl(Vector(("3",empty)))))))
+      ("kvp",Ogdl(Vector(
+        ("key",Ogdl(Vector(("None",empty)))),
+        ("value",Ogdl(Vector(("baz",Ogdl(Vector(("1",empty)))))))
+      ))),
+      ("kvp",Ogdl(Vector(
+        ("key",Ogdl(Vector(("Some",Ogdl(Vector(("A",empty))))))),
+        ("value",Ogdl(Vector(("baz",Ogdl(Vector(("2",empty)))))))
+      ))),
+      ("kvp",Ogdl(Vector(
+        ("key",Ogdl(Vector(("Some",Ogdl(Vector(("B",empty))))))),
+        ("value",Ogdl(Vector(("baz",Ogdl(Vector(("3",empty)))))))
+      ))),
+      ("kvp",Ogdl(Vector(
+        ("key",Ogdl(Vector(("None",empty)))),
+        ("value",Ogdl(Vector(("baz",Ogdl(Vector(("4",empty)))))))
+      )))
     ))))
 
     test("case class with a sorted set") {
-      implicit val index: Index[Quux] = Index("handle")
+      implicit val index: Index[Quux] = FieldIndex("handle")
       val input: Quux = Quux("Q", TreeSet("A", "B", "C"))
-      val x = Try{Ogdl(input)}
-      println(x)
-      x
+      Try{Ogdl(input)}
     }.assert(_ == Success(Ogdl(Vector(
       ("handle",Ogdl(Vector(("Q",empty)))),
       ("data",Ogdl(Vector(

--- a/src/ogdl-test/testwriter.scala
+++ b/src/ogdl-test/testwriter.scala
@@ -64,24 +64,18 @@ object OgdlWriterTest extends TestApp {
     ))))
 
     test("list of strings") {
-      val input = List("3", "2", "1")
+      val input = List("foo", "bar", "baz")
       Try{Ogdl(input)}
     }.assert(_ == Success(
-      Ogdl(Vector(
-        ("3",Ogdl(Vector(("3",empty)))),
-        ("2",Ogdl(Vector(("2",empty)))),
-        ("1",Ogdl(Vector(("1",empty))))
-      ))
+      Ogdl(Vector(("foo", Ogdl(Vector(("bar", Ogdl(Vector(("baz", empty)))))))))
     ))
 
     test("sorted set of integers") {
       val input: SortedSet[Int] = TreeSet(1, 2, 3)
       Try{Ogdl(input)}
-    }.assert(_ == Success(Ogdl(Vector(
-      ("1",Ogdl(Vector(("1",empty)))),
-      ("2",Ogdl(Vector(("2",empty)))),
-      ("3",Ogdl(Vector(("3",empty))))
-    ))))
+    }.assert(_ == Success(
+      Ogdl(Vector(("1", Ogdl(Vector(("2", Ogdl(Vector(("3", empty)))))))))
+    ))
 
     test("sorted set of case classes") {
       implicit val index: Index[Foo] = FieldIndex("bar")
@@ -116,11 +110,7 @@ object OgdlWriterTest extends TestApp {
       Try{Ogdl(input)}
     }.assert(_ == Success(Ogdl(Vector(
       ("handle",Ogdl(Vector(("Q",empty)))),
-      ("data",Ogdl(Vector(
-        ("A",Ogdl(Vector(("A",empty)))),
-        ("B",Ogdl(Vector(("B",empty)))),
-        ("C",Ogdl(Vector(("C",empty))))
-      )))
+      ("data",Ogdl(Vector(("A", Ogdl(Vector(("B", Ogdl(Vector(("C", empty))))))))))
     ))))
   }
 }

--- a/src/ogdl-test/testwriter.scala
+++ b/src/ogdl-test/testwriter.scala
@@ -43,7 +43,6 @@ object OgdlWriterTest extends TestApp {
         )))
       ))
       input.selectDynamic("permission")()
-      //FIXME I'm almost certain that the output should be "permission.name1:target1"
     }.assert(_ == "id")
 
     test("string") {
@@ -88,11 +87,10 @@ object OgdlWriterTest extends TestApp {
       implicit val index: Index[Foo] = FieldIndex("bar")
       val input: SortedSet[Foo] = TreeSet(Foo(bar = "A", baz = 2), Foo(bar = "B", baz = 3), Foo(bar = "B", baz = 1))
       Try{Ogdl(input)}
-      //TODO think of a more compact format
     }.assert(_ == Success(Ogdl(Vector(
-      ("kvp",Ogdl(Vector(("key",Ogdl(Vector(("B",empty)))), ("value",Ogdl(Vector(("baz",Ogdl(Vector(("1",empty)))))))))),
-      ("kvp",Ogdl(Vector(("key",Ogdl(Vector(("A",empty)))), ("value",Ogdl(Vector(("baz",Ogdl(Vector(("2",empty)))))))))),
-      ("kvp",Ogdl(Vector(("key",Ogdl(Vector(("B",empty)))), ("value",Ogdl(Vector(("baz",Ogdl(Vector(("3",empty))))))))))
+      ("B",Ogdl(Vector(("baz",Ogdl(Vector(("1",empty))))))),
+      ("A",Ogdl(Vector(("baz",Ogdl(Vector(("2",empty))))))),
+      ("B",Ogdl(Vector(("baz",Ogdl(Vector(("3",empty)))))))
     ))))
 
     test("sorted set of case classes with complex index") {
@@ -106,22 +104,10 @@ object OgdlWriterTest extends TestApp {
       //FIXME Uniqueness of the index field is not quaranteed
       Try{Ogdl(input)}
     }.assert(_ == Success(Ogdl(Vector(
-      ("kvp",Ogdl(Vector(
-        ("key",Ogdl(Vector(("None",empty)))),
-        ("value",Ogdl(Vector(("baz",Ogdl(Vector(("1",empty)))))))
-      ))),
-      ("kvp",Ogdl(Vector(
-        ("key",Ogdl(Vector(("Some",Ogdl(Vector(("A",empty))))))),
-        ("value",Ogdl(Vector(("baz",Ogdl(Vector(("2",empty)))))))
-      ))),
-      ("kvp",Ogdl(Vector(
-        ("key",Ogdl(Vector(("Some",Ogdl(Vector(("B",empty))))))),
-        ("value",Ogdl(Vector(("baz",Ogdl(Vector(("3",empty)))))))
-      ))),
-      ("kvp",Ogdl(Vector(
-        ("key",Ogdl(Vector(("None",empty)))),
-        ("value",Ogdl(Vector(("baz",Ogdl(Vector(("4",empty)))))))
-      )))
+      ("None",Ogdl(Vector(("baz",Ogdl(Vector(("1",empty))))))),
+      ("kvp",Ogdl(Vector(("bar",Ogdl(Vector(("Some",Ogdl(Vector(("A",empty))))))), ("value",Ogdl(Vector(("baz",Ogdl(Vector(("2",empty)))))))))),
+      ("kvp",Ogdl(Vector(("bar",Ogdl(Vector(("Some",Ogdl(Vector(("B",empty))))))), ("value",Ogdl(Vector(("baz",Ogdl(Vector(("3",empty)))))))))),
+      ("None",Ogdl(Vector(("baz",Ogdl(Vector(("4",empty)))))))
     ))))
 
     test("case class with a sorted set") {

--- a/src/ogdl-test/testwriter.scala
+++ b/src/ogdl-test/testwriter.scala
@@ -1,0 +1,127 @@
+/*
+
+    Fury, version 0.12.3. Copyright 2018-20 Jon Pretty, Propensive OÜ.
+
+    The primary distribution site is: https://propensive.com/
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+    compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License is
+    distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and limitations under the License.
+
+*/
+package fury.ogdl
+
+import probably._
+
+import scala.collection.immutable.{SortedSet, TreeSet}
+import scala.language.implicitConversions
+import scala.util.{Try, Success}
+
+object OgdlWriterTest extends TestApp {
+  private[this] val empty = Ogdl(Vector())
+
+  private[this] case class Foo(bar: String, baz: Int)
+  private[this] implicit val ord: Ordering[Foo] = Ordering[Int].on[Foo](_.baz)
+
+  private[this] case class Foo2(bar: Option[String], baz: Int)
+  private[this] implicit val ord2: Ordering[Foo2] = Ordering[Int].on[Foo2](_.baz)
+
+  private[this] case class Quux(handle: String, data: SortedSet[String])
+
+  override def tests(): Unit = {
+    test("select dynamic") {
+      val input = Ogdl(Vector(
+        ("scope",Ogdl(Vector(("DirectoryScope",Ogdl(Vector(("xxx",empty))))))),
+        ("permission",Ogdl(Vector(
+          ("id",Ogdl(Vector(("permission.name1:target1",empty)))),
+          ("action",Ogdl(Vector(("None",empty))))
+        )))
+      ))
+      input.selectDynamic("permission")()
+      //FIXME I'm almost certain that the output should be "permission.name1:target1"
+    }.assert(_ == "id")
+
+    test("string") {
+      val input: String = "Hello World!"
+      Try(Ogdl(input))
+    }.assert(_ == Success(Ogdl(Vector(("Hello World!", empty)))))
+
+    test("option") {
+      val input: Option[Boolean] = Some(false)
+      Try(Ogdl(input))
+    }.assert(_ == Success(Ogdl(Vector(("Some",Ogdl(Vector(("false",empty))))))))
+
+    test("case class") {
+      val input = Foo(bar = "1", baz = 2)
+      Try(Ogdl(input))
+    }.assert(_ == Success(Ogdl(Vector(
+      ("bar",Ogdl(Vector(("1", empty)))),
+      ("baz",Ogdl(Vector(("2", empty))))
+    ))))
+
+    test("list of strings") {
+      val input = List("3", "2", "1")
+      val x = Try{Ogdl(input)}
+      println(x)
+      x
+    }.assert(_ == Success(
+      Ogdl(Vector(
+        ("3",Ogdl(Vector(("3",empty)))),
+        ("2",Ogdl(Vector(("2",empty)))),
+        ("1",Ogdl(Vector(("1",empty))))
+      ))
+    ))
+
+    test("sorted set of integers") {
+      val input: SortedSet[Int] = TreeSet(1, 2, 3)
+      val x = Try{Ogdl(input)}
+      println(x)
+      x
+    }.assert(_ == Success(Ogdl(Vector(
+      ("1",Ogdl(Vector(("1",empty)))),
+      ("2",Ogdl(Vector(("2",empty)))),
+      ("3",Ogdl(Vector(("3",empty))))
+    ))))
+
+    test("sorted set of case classes") {
+      implicit val index: Index[Foo] = Index("bar")
+      val input: SortedSet[Foo] = TreeSet(Foo(bar = "A", baz = 2), Foo(bar = "B", baz = 3), Foo(bar = "B", baz = 1))
+      Try{Ogdl(input)}
+    }.assert(_ == Success(Ogdl(Vector(
+      ("B",Ogdl(Vector(("baz",Ogdl(Vector(("1",empty))))))),
+      ("A",Ogdl(Vector(("baz",Ogdl(Vector(("2",empty))))))),
+      ("B",Ogdl(Vector(("baz",Ogdl(Vector(("3",empty)))))))
+    ))))
+
+    test("sorted set of case classes 2") {
+      implicit val index: Index[Foo2] = Index("bar")
+      val input: SortedSet[Foo2] = TreeSet(Foo2(bar = Some("A"), baz = 2), Foo2(bar = Some("B"), baz = 3), Foo2(bar = None, baz = 1))
+      Try{Ogdl(input)}
+      //FIXME value of the option is lost
+    }.assert(_ == Success(Ogdl(Vector(
+      ("None",Ogdl(Vector(("baz",Ogdl(Vector(("1",empty))))))),
+      ("Some",Ogdl(Vector(("baz",Ogdl(Vector(("2",empty))))))),
+      ("Some",Ogdl(Vector(("baz",Ogdl(Vector(("3",empty)))))))
+    ))))
+
+    test("case class with a sorted set") {
+      implicit val index: Index[Quux] = Index("handle")
+      val input: Quux = Quux("Q", TreeSet("A", "B", "C"))
+      val x = Try{Ogdl(input)}
+      println(x)
+      x
+    }.assert(_ == Success(Ogdl(Vector(
+      ("handle",Ogdl(Vector(("Q",empty)))),
+      ("data",Ogdl(Vector(
+        ("A",Ogdl(Vector(("A",empty)))),
+        ("B",Ogdl(Vector(("B",empty)))),
+        ("C",Ogdl(Vector(("C",empty))))
+      )))
+    ))))
+  }
+}

--- a/src/ogdl/ogdlreader.scala
+++ b/src/ogdl/ogdlreader.scala
@@ -63,24 +63,43 @@ object OgdlReader {
   implicit val theme: OgdlReader[Theme] = ogdl => Theme.unapply(ogdl()).getOrElse(Theme.Full)
 
   implicit def traversable[Coll[t] <: Traversable[t], T: OgdlReader: Index](
+  implicit cbf: CanBuildFrom[Nothing, T, Coll[T]]
+  ): OgdlReader[Coll[T]] = implicitly[Index[T]] match {
+      case fi@FieldIndex(_) => complexTraversable[Coll, T](implicitly[OgdlReader[T]], fi, cbf).read(_)
+      case si@SelfIndexed() => simpleTraversable[Coll, T](implicitly[OgdlReader[T]], si, cbf).read(_)
+    }
+
+  private def simpleTraversable[Coll[t] <: Traversable[t], T: OgdlReader: SelfIndexed](
+      implicit cbf: CanBuildFrom[Nothing, T, Coll[T]]
+    ): OgdlReader[Coll[T]] = {
+    case Ogdl(vector) =>
+      if(vector.isEmpty) Vector[T]().to[Coll]
+      else {
+        vector.head match {
+          case (f, r) =>
+            val first = implicitly[OgdlReader[T]].read(Ogdl(f))
+            val rest = simpleTraversable[Coll, T].read(r)
+            (first +: rest.toSeq).to[Coll]
+        }
+      }
+  }
+
+  private def complexTraversable[Coll[t] <: Traversable[t], T: OgdlReader: FieldIndex](
       implicit cbf: CanBuildFrom[Nothing, T, Coll[T]]
     ): OgdlReader[Coll[T]] = {
     case Ogdl(vector) =>
       if(vector.head._1 == "") Vector[T]().to[Coll]
       else
         vector.map { element =>
-          val index = implicitly[Index[T]]
-          val data: Ogdl = index match {
-            case FieldIndex(field) => element match {
-              case ("kvp", kvp) =>
-                val key = Ogdl(Vector(field -> kvp.selectDynamic(field)))
-                val rest = kvp.selectDynamic("value")
-                Ogdl(key.values ++ rest.values)
-              case (single, rest) =>
-                val key = Ogdl(Vector(field -> Ogdl(Vector(single -> Ogdl(Vector())))))
-                Ogdl(key.values ++ rest.values)
-            }
-            case SelfIndexed() => Ogdl(element._1)
+          val index = implicitly[FieldIndex[T]]
+          val data: Ogdl = element match {
+            case ("kvp", kvp) =>
+              val key = Ogdl(Vector(index.field -> kvp.selectDynamic(index.field)))
+              val rest = kvp.selectDynamic("value")
+              Ogdl(key.values ++ rest.values)
+            case (single, rest) =>
+              val key = Ogdl(Vector(index.field -> Ogdl(Vector(single -> Ogdl(Vector())))))
+              Ogdl(key.values ++ rest.values)
           }
           implicitly[OgdlReader[T]].read(data)
         }.to[Coll]

--- a/src/ogdl/ogdlreader.scala
+++ b/src/ogdl/ogdlreader.scala
@@ -69,7 +69,11 @@ object OgdlReader {
       if(vector.head._1 == "") Vector[T]().to[Coll]
       else
         vector.map { v =>
-          val data: Ogdl = Ogdl((implicitly[Index[T]].index, Ogdl(v._1)) +: v._2.values)
+          val index = implicitly[Index[T]]
+          val data: Ogdl = index match {
+            case FieldIndex(field) => Ogdl((field, Ogdl(v._1)) +: v._2.values)
+            case SelfIndexed() => Ogdl(v._1)
+          }
           implicitly[OgdlReader[T]].read(data)
         }.to[Coll]
   }


### PR DESCRIPTION
This pull request should fix #1202.

## The problem 
The rules of OGDL serialization were updated so that elements of lists and sets are stored as key-value pairs, where the key ("index") is one of the fields of the element object, and the value is a vector of all the other fields.
Example for `case class Foo (id: Id, data1: T1, data2: T2, ...)`:
```
collection-id  -->  ( * , * , * , ...)
                      |
                      \- Ogdl(id)  -->  ( * , * , ...)
                                          |   |
                                          \---+-- "data1" --> Ogdl(data1)
                                              |
                                              \-- "data2" --> Ogdl(data2)
```

However, this approach has two problems:
1. How to choose the index if the type `Foo` has no fields at all (e. g. `type Foo = String`)?
2. How to store the index if it is a complex type itself (e. g. for `case class Bar (id: Foo, data: T)`)?

## The solution

In the case when collection elements are primitive values (or strings), the value of each element is used as its index:
```
collection-id  -->  ( * , * , * , ...)
                      |   |   |
                      \---+---+-- element1.toString --> Ogdl(element1)
                          |   |
                          \---+-- element2.toString --> Ogdl(element2)
                              |
                              \-- element3.toString --> Ogdl(element3)
```

In the case when the index is an object which itself has fields, an artificial OGDL node is constructed, which stores both the index object and the rest of the collection element:

```
collection-id  -->  ( * , * , * , ...)
                      |
                      \-- "kvp" --> ( * , * )
                                      |   |
                                      \---+-- "id" --> Ogdl(id)
                                          |
                                          \-- "value" --> ( * , * , ...)
                                                            |   |
                                                            \---+-- "data1" --> Ogdl(data1)
                                                                |
                                                                \-- "data2" --> Ogdl(data2)
```
For the latter case, the node names "kvp" and "value" are hardcoded. These are special names for the nodes that must be created for the purpose od serialization, and don't correspond directly  to any Scala object.

See the tests for live examples. However, to run these tests you'll have to restore a test module which has been lost some time ago.