### PR TITLE
Use the ANSI reset code only if it is defined in the theme

### DIFF
--- a/src/core/logging.scala
+++ b/src/core/logging.scala
@@ -76,7 +76,7 @@ case class LogStyle(printWriter: () => PrintWriter, timestamps: Option[Boolean],
     val bold: String = if(level >= Log.Warn) theme.bold() else ""
     
     printWriter().append(msg.string(theme).split("\n").map { line =>
-      s"$wipe$fTime$fLevel$paddedSession$bold$line${Ansi.reset()}"
+      s"$wipe$fTime$fLevel$paddedSession$bold$line${theme.reset()}"
     }.mkString("", "\n", "\n"))
     
     printWriter().flush()


### PR DESCRIPTION
This change is required to fix output comparison for the integration tests.