### PR TITLE
Refactored the commands related to dependencies

### DIFF
--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -101,6 +101,7 @@ case class ConfigCli(cli: Cli)(implicit log: Log) {
     _      <- ~log.infoWhen(!raw)(conf.focus())
     _      <- ~log.rawln(table)
   } yield log.await()
+
 }
 
 case class AboutCli(cli: Cli)(implicit log: Log) {

--- a/src/core/cli.scala
+++ b/src/core/cli.scala
@@ -180,10 +180,11 @@ class Cli(val stdout: java.io.PrintWriter,
   def action(blk: Call => Try[ExitStatus])(implicit log: Log): Try[ExitStatus] = call().flatMap(blk)
 
   def peek(param: CliParam): Option[param.Type] = args.get(param.param).toOption
-  
   def preview(param: CliParam)(default: Option[param.Type] = None): Try[param.Type] = {
     val result = args.get(param.param)
-    if(default.isDefined) result.recover { case _: Exception => default.get } else result
+    if(default.isDefined) result.recover {
+        case _: exoskeleton.MissingArg => default.get
+    } else result
   }
 
   def pwd: Try[Path] = env.workDir.ascribe(FileNotFound(Path("/"))).map(Path(_))


### PR DESCRIPTION
The commands related to dependency management are refactored to keep both command completions and meaningful error messages.

The commit 1ba336e47a26782370f75d4625f54f75e250ad52 is reverted, because caused the issue #1088 to reappear.

This pull request is related to issues #1088 and #1222.