### PR TITLE
Precise return type for Cli.askProjectAndModule

### DIFF
--- a/src/core/cli.scala
+++ b/src/core/cli.scala
@@ -195,7 +195,9 @@ class Cli(val stdout: java.io.PrintWriter,
     }
   }
 
-  def askProjectAndModule(layer: Layer): Try[(Cli, Try[Project], Try[Module])] = {
+  def askProjectAndModule(layer: Layer): Try[(Cli{
+    type Hinted <: cli.Hinted with Args.ProjectArg.type with Args.ModuleArg.type
+  }, Try[Project], Try[Module])] = {
     import fury.core.Args.{ ProjectArg, ModuleArg }
     for {
       cli          <- this.hint(ProjectArg, layer.projects)


### PR DESCRIPTION
This improvement allows to use `Cli.askProjectAndModule(_ :Layer)` anywhere in the hint construction block. Previously, putting it after hints for other arguments sometimes resulted in compilation errors:
```
Output from fury/source
[E] fury/source>local:src/source/source.scala:91:25
| Cannot prove that cli.Hinted <:< fury.core.<refinement>.type.
| source       <- call(SourceArg)
[E] fury/source>local:src/source/source.scala:94:40
| missing parameter type
| localId      <- tryLocalRepo.map { r => layer.repos.find(_.repo.simplified == r.simplified).map(_.id) }
[E] fury/source>local:src/source/source.scala:96:42
| type mismatch;
|  found   : Any
|  required: fury.core.Source
| source       <- ~Source.rewriteLocal(source, localId)

```