### PR TITLE
Fixed the regex for layer references by IPFS hash

### DIFF
--- a/src/model/ids.scala
+++ b/src/model/ids.scala
@@ -573,8 +573,8 @@ object LayerName {
   def parse(path: String): Try[LayerName] = {
     val service = ManagedConfig().service
     path match {
-      case r"fury:\/\/$ref@([A-Za-z0-9]{44})\/?" =>
-        Success(IpfsRef(str"Qm$ref"))
+      case r"fury:\/\/$ref@(Qm[A-Za-z0-9]{44})\/?" =>
+        Success(IpfsRef(ref))
       case r"fury:\/\/$dom@(([a-z]+\.)+[a-z]{2,})\/$loc@(([a-z][a-z0-9]*\/)+[a-z][0-9a-z]*([\-.][0-9a-z]+)*)" =>
         Success(FuryUri(DomainName(dom), loc))
       case r".*\.fury" =>


### PR DESCRIPTION
Currently the regex intended to match IPFS hashes assumes wrong length of the hash. As a result, arguments like `fury://QmdggygQu3X9cMfv4oy7tdFGxvSgUNvA6qokjppeewU9sZ` are not recognized as valid layer references.