### PR TITLE
Don't force exit after the Nailgun server is stopped

### DIFF
--- a/etc/fury
+++ b/etc/fury
@@ -54,8 +54,8 @@ coursier() {
 stopFury() {
   nailgun "${FURY_MAIN}" "$$" "stop" 2> /dev/null
   case "$?" in
-    0)   nailgun ng-stop && exit 0 ;;
-    230) echo "Fury is not running." && exit 1 ;;
+    0)   nailgun ng-stop ;;
+    230) echo "Fury is not running." ;;
     *)   exit 1 ;;
   esac
 }

--- a/etc/fury
+++ b/etc/fury
@@ -55,7 +55,7 @@ stopFury() {
   nailgun "${FURY_MAIN}" "$$" "stop" 2> /dev/null
   case "$?" in
     0)   nailgun ng-stop ;;
-    230) echo "Fury is not running." ;;
+    230) echo "Fury is not running." && exit 1 ;;
     *)   exit 1 ;;
   esac
 }


### PR DESCRIPTION
The [`exit`](https://www.tldp.org/LDP/abs/html/exit-status.html) command terminates the whole script, not just the function. Also, if exit code 230 means that Fury is not running, then this outcome is as good as success for the stop command. In particular, it is not unreasonable to "restart" Fury even if it wasn't running.

Fixes #1352.