### PR TITLE
guard for attempting to add duplicate project names

### DIFF
--- a/src/project/project.scala
+++ b/src/project/project.scala
@@ -74,7 +74,8 @@ case class ProjectCli(cli: Cli)(implicit log: Log) {
                         ModuleRef.parseFull(v, true).ascribe(InvalidValue(v))
                       }.sequence.map(_.headOption)
 
-    projectId      <- call(ProjectNameArg)
+    projectArg     <- call(ProjectNameArg)
+    projectId      <- layer.projects.unique(projectArg)
     license        <- Success(call(LicenseArg).toOption.getOrElse(License.unknown))
     project        <- ~Project(projectId, license = license, compiler = optCompilerRef)
     layer          <- ~Layer(_.projects).modify(layer)(_ + project)


### PR DESCRIPTION
'fury project add -n xxx" does not check for duplicate projects name, thus overwrites it. Some previous issues mentioned shading over names, but that was mostly related to layer imports. If you're manually adding your project name to a layer, then it's reasonable to enforce a uniqueness constraint.

closes #1358 