### PR TITLE
evict old class files for correct jar artifact

### DIFF
--- a/src/compile/compile.scala
+++ b/src/compile/compile.scala
@@ -611,7 +611,7 @@ case class Compilation(target: Target,
       _                 = if(fatJar) log.info(msg"Wrote ${path.size} to ${path.relativizeTo(layout.baseDir)}")
                           else log.info(msg"Wrote ${bins.size + 1} JAR files (total ${bins.foldLeft(ByteSize(0
                               ))(_ + _.size)}) to ${path.parent.relativizeTo(layout.baseDir)}")
-
+      _                <- stagingDirectory.delete
     } yield ()
   }
 

--- a/src/compile/compile.scala
+++ b/src/compile/compile.scala
@@ -599,6 +599,7 @@ case class Compilation(target: Target,
       path              = (dest / str"${ref.projectId.key}-${ref.moduleId.key}.jar")
       enc               = System.getProperty("file.encoding")
       _                 = log.info(msg"Saving JAR file ${path.relativizeTo(layout.baseDir)} using ${enc}")
+
       stagingDirectory <- aggregateCompileResults(ref, srcs, layout)
       resources        <- aggregatedResources(ref)
       _                <- resources.traverse(_.copyTo(checkouts, layout, stagingDirectory))

--- a/src/compile/compile.scala
+++ b/src/compile/compile.scala
@@ -602,7 +602,6 @@ case class Compilation(target: Target,
       stagingDirectory <- aggregateCompileResults(ref, srcs, layout)
       resources        <- aggregatedResources(ref)
       _                <- resources.traverse(_.copyTo(checkouts, layout, stagingDirectory))
-      
       _                <- Shell(layout.env).jar(path, if(fatJar) bins else Set.empty,
                               stagingDirectory.children.map(stagingDirectory / _).to[Set], manifest)
 

--- a/src/compile/compile.scala
+++ b/src/compile/compile.scala
@@ -599,7 +599,6 @@ case class Compilation(target: Target,
       path              = (dest / str"${ref.projectId.key}-${ref.moduleId.key}.jar")
       enc               = System.getProperty("file.encoding")
       _                 = log.info(msg"Saving JAR file ${path.relativizeTo(layout.baseDir)} using ${enc}")
-
       stagingDirectory <- aggregateCompileResults(ref, srcs, layout)
       resources        <- aggregatedResources(ref)
       _                <- resources.traverse(_.copyTo(checkouts, layout, stagingDirectory))

--- a/src/core/policy.scala
+++ b/src/core/policy.scala
@@ -43,7 +43,12 @@ object Policy {
   }
   
   def standardPrivileges: List[Privilege] =
-    List(Privilege(GlobalScope, Permission(ClassRef("java.util.PropertyPermission"), "scala.*", Some("read"))))
+    List(
+      Privilege(GlobalScope, Permission(ClassRef("java.util.PropertyPermission"), "scala.*", Some("read"))),
+      Privilege(GlobalScope, Permission(ClassRef("java.lang.RuntimePermission"), "accessClassInPackage.sun.misc", None)),
+      Privilege(GlobalScope, Permission(ClassRef("java.lang.RuntimePermission"), "accessDeclaredMembers", None)),
+      Privilege(GlobalScope, Permission(ClassRef("java.lang.reflect.ReflectPermission"), "suppressAccessChecks", None)),
+    )
 }
 
 case class Policy(version: Int, policy: SortedSet[Privilege] = TreeSet()) {

--- a/src/source/source.scala
+++ b/src/source/source.scala
@@ -67,7 +67,7 @@ case class SourceCli(cli: Cli)(implicit log: Log) {
     
     _            <- if(!module.sources.contains(source)) Failure(InvalidSource(source, module.ref(project)))
                         else Success(())
-
+    _            <- layout.classesDir(TargetId(module.ref(project))).delete
     layer        <- ~Layer(_.projects(project.id).modules(module.id).sources).modify(layer)(_ - source)
     _            <- Layer.commit(layer, conf, layout)
     _            <- ~Compilation.asyncCompilation(layer, module.ref(project), layout)

--- a/test/passing/class-eviction/check
+++ b/test/passing/class-eviction/check
@@ -12,14 +12,14 @@ Opening a BSP server connection
 BSP server is listening for incoming connections
 Saving JAR file out/cache-test-my-module.jar using UTF-8
 Wrote 5 JAR files (total 19.0 MiB) to out
-META-INF/MANIFEST.MF
 libA/LibA$.class
 libA/LibA.class
 LibB$.class
 LibB.class
+META-INF/MANIFEST.MF
 Saving JAR file out/cache-test-my-module.jar using UTF-8
 Wrote 5 JAR files (total 19.0 MiB) to out
-META-INF/MANIFEST.MF
 libA/LibA$.class
 libA/LibA.class
+META-INF/MANIFEST.MF
 0

--- a/test/passing/class-eviction/check
+++ b/test/passing/class-eviction/check
@@ -7,17 +7,19 @@ Set current module to my-module
 e36c63fb9ddb0d9027f4e634bd6440182ffdf4e338677debeda2634d3a81ae5a
 3ec0e1fb27a66a480065ccbf94030af08b66f3b70cb6e2bdc45d151b0c247085
 86dd1afef5ff30893a715c62702d27e2b479c2a32be773f000902f93e5bb0f6e
-Starting
-Opening
-BSP
-Saving
-Wrote
+Starting the BSP launcher...
+Opening a BSP server connection
+BSP server is listening for incoming connections
+Saving JAR file out/cache-test-my-module.jar using UTF-8
+Wrote 5 JAR files (total 19.0 MiB) to out
+META-INF/MANIFEST.MF
 libA/LibA$.class
 libA/LibA.class
 LibB$.class
 LibB.class
-Saving
-Wrote
+Saving JAR file out/cache-test-my-module.jar using UTF-8
+Wrote 5 JAR files (total 19.0 MiB) to out
+META-INF/MANIFEST.MF
 libA/LibA$.class
 libA/LibA.class
-1
+0

--- a/test/passing/class-eviction/check
+++ b/test/passing/class-eviction/check
@@ -1,0 +1,23 @@
+Initialized an empty layer
+Set current project to scala
+Set current module to compiler
+Set current project to cache-test
+Setting default compiler for project cache-test to scala/compiler
+Set current module to my-module
+e36c63fb9ddb0d9027f4e634bd6440182ffdf4e338677debeda2634d3a81ae5a
+3ec0e1fb27a66a480065ccbf94030af08b66f3b70cb6e2bdc45d151b0c247085
+86dd1afef5ff30893a715c62702d27e2b479c2a32be773f000902f93e5bb0f6e
+Starting
+Opening
+BSP
+Saving
+Wrote
+libA/LibA$.class
+libA/LibA.class
+LibB$.class
+LibB.class
+Saving
+Wrote
+libA/LibA$.class
+libA/LibA.class
+1

--- a/test/passing/class-eviction/description
+++ b/test/passing/class-eviction/description
@@ -1,0 +1,1 @@
+Old class files should be evicted when sources are removed, so that they are not included in classpath during jar creation

--- a/test/passing/class-eviction/script
+++ b/test/passing/class-eviction/script
@@ -1,0 +1,24 @@
+fury layer init
+fury project add -n scala
+fury module add -n compiler -t compiler
+fury module update -C scala-lang.org:scala-compiler:2.12.8
+fury binary add -b org.scala-lang:scala-compiler:2.12.8
+fury project add -n cache-test
+fury module add -n my-module -c scala/compiler
+fury permission require -C java.util.PropertyPermission -T test.property -A read
+fury permission require -C java.lang.RuntimePermission -T getenv.TEST1
+fury permission require -C java.io.FilePermission -T '.content' -A write
+mkdir -p src/libA
+fury source add -s src/libA
+echo 'package libA; object LibA { val aVal = "A" }' > src/libA/liba.scala
+mkdir libB
+fury source add -s libB
+echo 'object LibB { val bVal = "B" }' >> libB/libb.scala
+fury build run -F -f out --output quiet | awk '{print $1}'
+jar -tf out/cache-test-my-module.jar | grep LibA
+jar -tf out/cache-test-my-module.jar | grep LibB
+fury source remove -s libB
+fury build run -F -f out --output quiet | awk '{print $1}'
+jar -tf out/cache-test-my-module.jar | grep LibA
+jar -tf out/cache-test-my-module.jar | grep LibB
+echo $?

--- a/test/passing/class-eviction/script
+++ b/test/passing/class-eviction/script
@@ -14,11 +14,9 @@ echo 'package libA; object LibA { val aVal = "A" }' > src/libA/liba.scala
 mkdir libB
 fury source add -s libB
 echo 'object LibB { val bVal = "B" }' >> libB/libb.scala
-fury build run -F -f out --output quiet | awk '{print $1}'
-jar -tf out/cache-test-my-module.jar | grep LibA
-jar -tf out/cache-test-my-module.jar | grep LibB
+fury build run -f out --output quiet
+jar -tf out/cache-test-my-module.jar
 fury source remove -s libB
-fury build run -F -f out --output quiet | awk '{print $1}'
-jar -tf out/cache-test-my-module.jar | grep LibA
-jar -tf out/cache-test-my-module.jar | grep LibB
+fury build run -f out --output quiet
+jar -tf out/cache-test-my-module.jar
 echo $?

--- a/test/passing/class-eviction/script
+++ b/test/passing/class-eviction/script
@@ -15,8 +15,8 @@ mkdir libB
 fury source add -s libB
 echo 'object LibB { val bVal = "B" }' >> libB/libb.scala
 fury build run -f out --output quiet
-jar -tf out/cache-test-my-module.jar
+jar -tf out/cache-test-my-module.jar | LC_ALL=A sort --ignore-case
 fury source remove -s libB
 fury build run -f out --output quiet
-jar -tf out/cache-test-my-module.jar
+jar -tf out/cache-test-my-module.jar | LC_ALL=A sort --ignore-case
 echo $?

--- a/test/passing/scala3/check
+++ b/test/passing/scala3/check
@@ -4,9 +4,6 @@ Set current module to compiler
 Set current project to hello-world
 Setting default compiler for project hello-world to scala3/compiler
 Set current module to app
-c748caf8326e954c0664b6b4b73af730d7a1a7dd0080003dccafea6d29aa30a2
-de4484d63d30da772489c853637fabeeba4ad3e9477ad0718bddf7919758482f
-be0a4c03621cfd7edcbe393b33181af624ed5fbc0392b4768da79fae078430d6
 Starting the BSP launcher...
 Opening a BSP server connection
 BSP server is listening for incoming connections

--- a/test/passing/scala3/script
+++ b/test/passing/scala3/script
@@ -8,9 +8,6 @@ fury project add -n hello-world
 fury module add -n app -c scala3/compiler -t application -M HelloWorld
 fury source add -s src
 mkdir -p src
-fury permission require -C java.lang.RuntimePermission -T accessClassInPackage.sun.misc
-fury permission require -C java.lang.RuntimePermission -T accessDeclaredMembers
-fury permission require -C java.lang.reflect.ReflectPermission -T suppressAccessChecks
 #fury build run --output quiet >> /dev/null
 fury build run --output linear
 echo $?


### PR DESCRIPTION
Old class files are being cached which is leading to incorrect jar artifacts (see my lengthy explanation regarding #1377 ). I think simply deleting a module's classes directory when sources are removed is the easiest fix. Since we only have source paths and bloop outputs to target directories, without a constraint between source paths and full qualified class names (which is as much a scala thing as it is fury), it seems virtually impossible to find and 'target delete' old class files. 
The staging directory where jars are created never gets deleted, so any class ever included in the manifest, will forever be included in a jar. Since this directory is not addressed by any of the existing clean mechanisms, simply deleting it after every jar creation does the trick.