### PR TITLE
Allow customization of REPL class for Scala 3

### DIFF
--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -413,14 +413,15 @@ case class BuildCli(cli: Cli)(implicit log: Log) {
                           msg"with an incomplete classpath")
                       Success(())
                     } else result
+    compilerMod  <- compilation.universe.getMod(module.compiler)
+    repl         <- ~compilerMod.kind.as[Compiler].get.repl
     classpath    <- ~compilation.classpath(module.ref(project), layout)
     bootCp       <- ~compilation.bootClasspath(module.ref(project), layout)
   } yield {
     val cp = classpath.map(_.value).join(":")
     val bcp = bootCp.map(_.value).join(":")
     cli.continuation(str"""java -Xmx256M -Xms32M -Xbootclasspath/a:$bcp -classpath $cp """+
-        str"""-Dscala.boot.class.path=$cp -Dscala.home=/opt/scala-2.12.8 -Dscala.usejavacp=true """+
-        str"""scala.tools.nsc.MainGenericRunner""")
+        str"""-Dscala.boot.class.path=$cp -Dscala.home=/opt/scala-2.12.8 -Dscala.usejavacp=true $repl""")
   }
 
   def classpath: Try[ExitStatus] = for {

--- a/src/core/args.scala
+++ b/src/core/args.scala
@@ -104,6 +104,7 @@ object Args {
   val RepoArg = CliParam[RepoId]('r', 'repo, "specify a repository")
   val RecursiveArg = CliParam[Unit]('r', 'recursive, "perform the operation recursively")
   val RetryArg = CliParam[Unit]('R', 'retry, "reattempt to download a remote repository")
+  val ReplArg = CliParam[ClassRef]('R', 'repl, "REPL class to use for console")
   
   private val allReporters = Reporter.all.map(_.name).mkString(", ")
   val ReporterArg = CliParam[Reporter]('o', 'output, s"format for build output ($allReporters)")

--- a/src/core/layer.scala
+++ b/src/core/layer.scala
@@ -351,17 +351,17 @@ object Layer extends Lens.Partial[Layer] {
       migrate((version match {
         case 9 =>
           Try(ogdl.set(projects = ogdl.projects.map { project =>
-            project.set(modules = project.modules.map { module => module.kind() match {
-              case "Compiler" =>
-                val newKind = Compiler(BloopSpec(module.kind.org(), module.kind.name(), module.kind.version()))
-                
-                module.set(kind = Ogdl[Kind](newKind))
-
-              case other      => module
-            } })
+            project.set(modules = project.modules.map { module =>
+              module.kind() match {
+                case "Compiler" =>
+                  val c = module.kind.Compiler
+                  module.set(kind = Ogdl[Kind](Compiler(BloopSpec(c.org(), c.name(), c.version()))))
+                case other      => module
+              } 
+            })
           })).getOrElse(ogdl)
 
-        case 8 =>
+        case 8 => // Expires 19 November 2020
           Try(ogdl.set(projects = ogdl.projects.map { project =>
             project.set(modules = project.modules.map { module =>
               lazy val main = Try(ClassRef(module.main.Some()))

--- a/src/model/kinds.scala
+++ b/src/model/kinds.scala
@@ -33,11 +33,11 @@ object Kind {
   implicit def stringShow: StringShow[Kind] = msgShow.show(_).string(Theme.NoColor)
 
   implicit def msgShow: MsgShow[Kind] = {
-    case Lib()            => msg"lib"
-    case App(main)        => msg"app${':'}$main"
-    case Plugin(id, main) => msg"plugin${':'}$main${':'}$id"
-    case Compiler(spec)   => msg"compiler${':'}$spec"
-    case Bench(main)      => msg"bench${':'}$main"
+    case Lib()                => msg"lib"
+    case App(main)            => msg"app${':'}$main"
+    case Plugin(id, main)     => msg"plugin${':'}$main${':'}$id"
+    case Compiler(spec, repl) => msg"compiler${':'}$spec"
+    case Bench(main)          => msg"bench${':'}$main"
   }
 }
 
@@ -46,11 +46,11 @@ sealed abstract class Kind(val needsExec: Boolean = false) {
   def is[T: ClassTag]: Boolean = this match { case t: T => true case _ => false }
   
   def name: Kind.Id = this match {
-    case Lib()        => Lib
-    case App(_)       => App
-    case Plugin(_, _) => Plugin
-    case Compiler(_)  => Compiler
-    case Bench(_)     => Bench
+    case Lib()          => Lib
+    case App(_)         => App
+    case Plugin(_, _)   => Plugin
+    case Compiler(_, _) => Compiler
+    case Bench(_)       => Bench
   }
 }
 
@@ -64,7 +64,8 @@ object Plugin extends Kind.Id("plugin")
 case class Plugin(id: PluginId, main: ClassRef) extends Kind()
 
 object Compiler extends Kind.Id("compiler")
-case class Compiler(spec: BloopSpec) extends Kind()
+case class Compiler(spec: BloopSpec, repl: ClassRef = ClassRef("scala.tools.nsc.MainGenericRunner")) extends
+    Kind()
 
 object Bench extends Kind.Id("bench")
 case class Bench(main: ClassRef) extends Kind(needsExec = true)

--- a/src/module/module.scala
+++ b/src/module/module.scala
@@ -116,7 +116,7 @@ case class ModuleCli(cli: Cli)(implicit log: Log) {
     cli         <- cli.hint(CompilerArg, ModuleRef.JavaRef :: layer.compilerRefs(layout))
     call        <- cli.call()
 
-    kind        <- parseKind(kindName.getOrElse(Lib), cli.peek(ReplArg), cli.peek(MainArg), cli.peek(SpecArg),
+    kind        <- parseKind(kindName.getOrElse(Lib), cli.peek(MainArg), cli.peek(ReplArg), cli.peek(SpecArg),
                        cli.peek(PluginArg))
     
     project     <- optProject.asTry

--- a/test/passing/layer-traversal/check
+++ b/test/passing/layer-traversal/check
@@ -5,7 +5,7 @@ Set current project to library
 Setting default compiler for project library to scala/compiler
 Set current module to core
 0
-IPFS ref: fury://QmXo5iUWZADcJXm9GTwvU2ZJbbKmsznUmE2EAQcMn7eApd
+IPFS ref: fury://QmXD9hmFYhkxwyLdDsPiFSsxjiU9mZmPwJUXYaRzmqHPjf
 Initialized an empty layer
 Checking that no modules reference local sources
 Checking that no project names conflict

--- a/test/passing/share-layer/check
+++ b/test/passing/share-layer/check
@@ -1,12 +1,12 @@
 Initialized an empty layer
-fury://QmfGy2Qkm2W15VVSrbwNRSJ7uVa9mxLsgauMmLpopMm42b
+fury://QmTowarZvqAjdRCatXv4DecCzM27vJYvFWauNNfrSGCU5S
 Set current project to example
 Set current module to core
-Qmf5guaP3ENv3NGB4gAVA2M1BvM2LUkzHNQjj7nTarQ6Co
+QmQDfuf7Zvkvu2NaavbPKB1aeR2yDNtvGjM2gF8VrTbNKA
 Checking that no modules reference local sources
 Checking that no project names conflict
 Checking that all module references resolve
-Cloning layer Qmf5guaP3ENv3NGB4gAVA2M1BvM2LUkzHNQjj7nTarQ6Co into layer2
+Cloning layer QmQDfuf7Zvkvu2NaavbPKB1aeR2yDNtvGjM2gF8VrTbNKA into layer2
 Saving Fury configuration file layer2/.fury/config
 Cloning complete
 core

--- a/test/passing/undo/check
+++ b/test/passing/undo/check
@@ -9,6 +9,6 @@ Set current module to app
 e36c63fb9ddb0d9027f4e634bd6440182ffdf4e338677debeda2634d3a81ae5a
 3ec0e1fb27a66a480065ccbf94030af08b66f3b70cb6e2bdc45d151b0c247085
 logging
-Reverted to layer X1Wu4AMC
+Reverted to layer P1Uij5aJ
 0
 


### PR DESCRIPTION
It still defaults to using the standard class if it's not specified.