### PR TITLE
Unfork repo even if the local copy does not exist

### DIFF
--- a/test/passing/repo-fork/check
+++ b/test/passing/repo-fork/check
@@ -26,3 +26,5 @@ Starting compilation of module hello-world/app
 Successfully compiled module hello-world/app
 Hello World!
 0
+Reverted to layer
+Unforking library from library-local which does not exist or is not a Git repository

--- a/test/passing/repo-fork/script
+++ b/test/passing/repo-fork/script
@@ -31,4 +31,7 @@ echo $?
 fury repo unfork -r library
 fury build run --output linear
 echo $?
+fury undo | sed -E 's/ [a-zA-Z0-9]+$//'
+rm -rf library-local
+fury repo unfork -r library
 


### PR DESCRIPTION
I think the unfork operation should succeed even if the fork directory is corrupt.

Closes #1448.