### PR TITLE
More manageable project conflicts

### DIFF
--- a/src/compile/bsp.scala
+++ b/src/compile/bsp.scala
@@ -111,7 +111,7 @@ class FuryBuildServer(layout: Layout, cancel: Cancelator)(implicit log: Log)
 
       graph          <- layer.projects.flatMap(_.moduleRefs).map { ref => for {
                           ds   <- universe.dependencies(ref, layout)
-                          arts <- (ds.map(_.ref) + ref).traverse(Target(_, universe, layout))
+                          arts <- (ds.map(_.ref) + ref).traverse(Target(_, hierarchy, universe, layout))
                         } yield arts.map { a =>
                           (a.ref, (a.module.dependencies.to[List]) ++ a.module.compiler().map(_.hide))
                         } }.sequence.map(_.flatten.toMap)
@@ -119,9 +119,9 @@ class FuryBuildServer(layout: Layout, cancel: Cancelator)(implicit log: Log)
       allModuleRefs  = graph.keys
       modules       <- allModuleRefs.traverse { ref => universe(ref).map((ref, _)) }
       targets       <- graph.keys.map { ref =>
-                         Target(ref, universe, layout).map(ref -> _)
+                         Target(ref, hierarchy, universe, layout).map(ref -> _)
                        }.sequence.map(_.toMap)
-      snapshots     <- graph.keys.map(universe.checkout(_, layout)).sequence
+      snapshots     <- graph.keys.map(universe.checkout(_, hierarchy, layout)).sequence
     } yield Structure(modules.toMap, graph, snapshots.foldLeft(Snapshots(Map()))(_ ++ _), targets)
 
   private def getBuild(structure: Structure, bti: BuildTargetIdentifier): Try[Build] = {

--- a/src/compile/compile.scala
+++ b/src/compile/compile.scala
@@ -637,8 +637,8 @@ case class Build(target: Target,
 
     for {
       staging <- aggregateResults(ref, srcs, layout)
-      entity  <- universe.entity(ref.projectId)
-      module  <- entity.project(ref.moduleId)
+      project <- universe(ref.projectId)
+      module  <- project(ref.moduleId)
       _       <- if(!js) saveJar(staging, module) else saveJs(staging, module)
       _       <- staging.delete()
     } yield ()

--- a/src/compile/compile.scala
+++ b/src/compile/compile.scala
@@ -239,33 +239,35 @@ object Build {
 
     hierarchy <- layer.hierarchy()
     universe  <- hierarchy.universe
-    build     <- Build(universe, dependency, layout)
+    build     <- Build(universe, dependency, hierarchy, layout)
     _         <- Policy.read(log).checkAll(build.requiredPermissions, noSecurity)
     _         <- build.generateFiles(layout)
   } yield build
 
-  def apply(universe: Universe, dependency: Dependency, layout: Layout)(implicit log: Log): Try[Build] = {
+  def apply(universe: Universe, dependency: Dependency, hierarchy: Hierarchy, layout: Layout)
+           (implicit log: Log)
+           : Try[Build] = {
     def directDependencies(target: Target): Set[Dependency] = target.module.dependencies ++ target.module.compiler()
     def canAffectBuild(target: Target): Boolean = !target.module.kind.is[Lib]
 
     def graph(target: Target): Try[Target.Graph] = for {
       requiredModules <- universe.dependencies(dependency.ref, layout)
-      requiredTargets <- requiredModules.map(_.ref).traverse(Target(_, universe, layout))
+      requiredTargets <- requiredModules.map(_.ref).traverse(Target(_, hierarchy, universe, layout))
     } yield {
       val targetGraph = (requiredTargets + target).map { t => t.ref -> directDependencies(t) }
       Target.Graph(targetGraph.toMap, requiredTargets.map { t => t.ref -> t }.toMap)
     }
 
     for {
-      target      <- Target(dependency.ref, universe, layout)
+      target      <- Target(dependency.ref, hierarchy, universe, layout)
       graph       <- graph(target)
 
       targetIndex <- graph.dependencies.keys.filter(_ != ModuleRef.JavaRef).traverse { ref =>
-                       Target(ref, universe, layout).map(ref -> _)
+                       Target(ref, hierarchy, universe, layout).map(ref -> _)
                      }
       
       targets      = targetIndex.unzip._2.to[Set]
-      snapshots   <- graph.dependencies.keys.filter(_ != ModuleRef.JavaRef).traverse(universe.checkout(_, layout))
+      snapshots   <- graph.dependencies.keys.filter(_ != ModuleRef.JavaRef).traverse(universe.checkout(_, hierarchy, layout))
       policy       = (if(target.module.kind.needsExec) targets else targets - target).flatMap(_.module.policy)
     } yield {
       val moduleRefToTarget = (targets ++ target.module.compiler().map { d => graph.targets(d.ref) }).map { t => t.ref -> t }.toMap

--- a/src/core/args.scala
+++ b/src/core/args.scala
@@ -101,6 +101,7 @@ object Args {
       "specify a specification for the compiler in the form <organization>:<compiler ID>:<version>")
 
   val ProjectArg = CliParam[ProjectId]('p', 'project, "specify a project")
+  val ProjectRefArg = CliParam[ProjectRef]('p', 'project, "specify a project")
   val OptArg = CliParam[OptId]('o', 'option, "compiler option")
   val PermissionArg = CliParam[List[String]]('P', 'permission, "permission entries")
   val PropArg = CliParam[JavaProperty]('D', 'property, "Java -D property")

--- a/src/core/hierarchy.scala
+++ b/src/core/hierarchy.scala
@@ -29,14 +29,9 @@ case class Hierarchy(layer: Layer, path: ImportPath, children: Map[ImportId, Hie
     def merge(getUniverse: Try[Universe], child: (ImportId, Hierarchy)): Try[Universe] = for {
       universe     <- getUniverse
       next         <- child._2.universe
-      candidates    = (universe.ids -- localProjectIds).intersect(next.ids)
-      conflictIds   = candidates.filter { id => universe(id) != next(id) }
+    } yield universe ++ next
 
-      newUniverse  <- if(conflictIds.isEmpty) Success(universe ++ next)
-                      else Failure(ProjectConflict(conflictIds, path, child._2.path))
-    } yield newUniverse
-
-    children.foldLeft(Try(Universe()))(merge).map(_ ++ layer.localUniverse(path))
+    children.foldLeft(Try(Universe(this)))(merge).map(_ ++ layer.localUniverse(this, path))
   }
 
   def apply(importPath: ImportPath): Try[Layer] =

--- a/src/core/layer.scala
+++ b/src/core/layer.scala
@@ -55,7 +55,7 @@ case class Layer(version: Int,
   })
 
   def localUniverse(path: ImportPath): Universe = Universe(
-    entities = projects.map { project => project.id -> Entity(project, Map(path -> this)) }.toMap,
+    entities = projects.map { project => project.id -> Entity(project, Set(path)) }.toMap,
     repoSets = repos.groupBy(_.commit.repoSetId).mapValues(_.map(_.ref(path))),
     imports = imports.map { i => i.layerRef.short -> LayerEntity(i.layerRef.short, Map(path -> i)) }.toMap
   )

--- a/src/core/layer.scala
+++ b/src/core/layer.scala
@@ -54,8 +54,9 @@ case class Layer(version: Int,
     })
   })
 
-  def localUniverse(path: ImportPath): Universe = Universe(
-    entities = projects.map { project => project.id -> Entity(project, Set(path)) }.toMap,
+  def localUniverse(hierarchy: Hierarchy, path: ImportPath): Universe = Universe(
+    hierarchy = hierarchy,
+    projects = projects.map { project => project.id -> Map(project.projectRef -> Set(path)) }.toMap,
     repoSets = repos.groupBy(_.commit.repoSetId).mapValues(_.map(_.ref(path))),
     imports = imports.map { i => i.layerRef.short -> LayerEntity(i.layerRef.short, Map(path -> i)) }.toMap
   )
@@ -75,8 +76,8 @@ case class Layer(version: Int,
     LocalSource(_, _) <- module.sources
   } yield module.ref(project)
 
-  def deepModuleRefs(universe: Universe): Set[ModuleRef] =
-    universe.entities.values.flatMap(_.project.moduleRefs).to[Set]
+  def deepModuleRefs(universe: Universe): Try[Set[ModuleRef]] =
+    for(projects <- universe.allProjects) yield projects.flatMap(_.moduleRefs).to[Set]
 
   def unresolvedModules(universe: Universe): Map[ModuleRef, Set[Dependency]] = { for {
     project    <- projects.to[List]

--- a/src/core/misc.scala
+++ b/src/core/misc.scala
@@ -26,17 +26,7 @@ import scala.util._
 
 import java.net.URI
 
-case class ProjectSpec(project: Project, repos: Map[RepoId, Repo])
-
-case class Entity(project: Project, layers: Map[ImportPath, Layer]) {
-
-  def repos: Set[Repo] = layers.head._2.repos
-
-  def spec: ProjectSpec = {
-    val repoIds = project.allRepoIds
-    ProjectSpec(project, repos.filter(repoIds contains _.id).map { r => (r.id, r) }.toMap)
-  }
-}
+case class Entity(project: Project, imports: Set[ImportPath])
 
 sealed trait CompileEvent
 case object Tick extends CompileEvent

--- a/src/core/project.scala
+++ b/src/core/project.scala
@@ -19,6 +19,7 @@ package fury.core
 import fury.model._, fury.text._
 
 import mercator._
+import gastronomy._
 
 import scala.util._
 import scala.collection.immutable._
@@ -39,6 +40,15 @@ case class Project(id: ProjectId,
                    license: LicenseId = License.unknown,
                    description: String = "",
                    compiler: Option[CompilerRef] = None) {
+
+  def projectRef: ProjectRef = {
+    val digest = (id, description, main, license, modules.map { m =>
+      (m.id, m.kind, m.manifest, m.compiler, m.dependencies.to[List], m.opts.to[List], m.binaries.to[List],
+          m.environment.to[List], m.policy.to[List], m.hidden, m.optDefs.to[List], m.deterministic,
+          (m.sources.to[List] ++ m.resources.to[List])) // FIXME: Resolve these in the hierarchy!
+    }.to[List]).digest[Sha256]
+    ProjectRef(id, digest.encoded[Hex].take(6))
+  }
 
   def apply(module: ModuleId): Try[Module] = modules.findBy(module)
   def moduleRefs: List[ModuleRef] = modules.to[List].map(_.ref(this))

--- a/src/core/tables.scala
+++ b/src/core/tables.scala
@@ -198,14 +198,23 @@ case class Tables() {
     if(importPaths.size > 4) fewPaths+"\n"+msg"...and ${importPaths.size - 4} more." else fewPaths
   }
 
-  def entities(current: Option[ProjectId]): Tabulation[Entity] = Tabulation(
-    Heading("", p => Some(p.project.id) == current),
-    Heading("Project", _.project.id),
-    Heading("Modules", p => p.project.modules.size),
-    Heading("Description", _.project.description),
-    Heading("License", _.project.license),
-    Heading("Compiler", _.project.compiler),
-    Heading("Layer(s)", p => showImportPaths(p.imports))
+  def entities(current: Option[ProjectId]): Tabulation[(Project, Set[ImportPath])] = Tabulation(
+    Heading("", p => Some(p._1.id) == current),
+    Heading("Project", _._1.projectRef),
+    Heading("Modules", p => p._1.modules.size),
+    Heading("Description", _._1.description),
+    Heading("License", _._1.license),
+    Heading("Compiler", _._1.compiler),
+    Heading("Layer(s)", p => showImportPaths(p._2))
+  )
+
+  def projects(current: Option[ProjectId]): Tabulation[Project] = Tabulation(
+    Heading("", p => Some(p.id) == current),
+    Heading("Project", _.id),
+    Heading("Modules", p => p.modules.size),
+    Heading("Description", _.description),
+    Heading("License", _.license),
+    Heading("Compiler", _.compiler)
   )
 
   def repos(layout: Layout)(implicit log: Log): Tabulation[Repo] = Tabulation(

--- a/src/core/tables.scala
+++ b/src/core/tables.scala
@@ -198,14 +198,10 @@ case class Tables() {
     if(importPaths.size > 4) fewPaths+"\n"+msg"...and ${importPaths.size - 4} more." else fewPaths
   }
 
-  def entities(current: Option[ProjectId]): Tabulation[(Project, Set[ImportPath])] = Tabulation(
-    Heading("", p => Some(p._1.id) == current),
-    Heading("Project", _._1.projectRef),
-    Heading("Modules", p => p._1.modules.size),
-    Heading("Description", _._1.description),
-    Heading("License", _._1.license),
-    Heading("Compiler", _._1.compiler),
-    Heading("Layer(s)", p => showImportPaths(p._2))
+  val entities: Tabulation[(ProjectRef, Project, Set[ImportPath])] = Tabulation(
+    Heading("Project", _._1),
+    Heading("Description", _._2.description),
+    Heading("Layers", p => showImportPaths(p._3))
   )
 
   def projects(current: Option[ProjectId]): Tabulation[Project] = Tabulation(

--- a/src/core/tables.scala
+++ b/src/core/tables.scala
@@ -205,7 +205,7 @@ case class Tables() {
     Heading("Description", _.project.description),
     Heading("License", _.project.license),
     Heading("Compiler", _.project.compiler),
-    Heading("Layer(s)", p => showImportPaths(p.layers.keys))
+    Heading("Layer(s)", p => showImportPaths(p.imports))
   )
 
   def repos(layout: Layout)(implicit log: Log): Tabulation[Repo] = Tabulation(

--- a/src/core/target.scala
+++ b/src/core/target.scala
@@ -34,17 +34,17 @@ object Target {
   def apply(ref: ModuleRef, hierarchy: Hierarchy, universe: Universe, layout: Layout)
            (implicit log: Log)
            : Try[Target] = for {
-      entity    <- universe.entity(ref.projectId)
-      module    <- entity.project(ref.moduleId)
+      project   <- universe(ref.projectId)
+      module    <- project(ref.moduleId)
       binaries  <- module.allBinaries.to[List].traverse(_.paths).map(_.flatten)
       checkouts <- universe.checkout(ref, hierarchy, layout)
       sources   <- module.sources.to[List].traverse(_.dir(checkouts, layout))
-    } yield Target(ref, module, entity, checkouts, sources, binaries )
+    } yield Target(ref, module, project, checkouts, sources, binaries )
 }
 
 case class Target(ref: ModuleRef,
                   module: Module,
-                  entity: Entity,
+                  project: Project,
                   snapshots: Snapshots,
                   sourcePaths: List[Path],
                   binaries: List[Path]) {

--- a/src/core/target.scala
+++ b/src/core/target.scala
@@ -31,11 +31,13 @@ object Target {
     lazy val dependencies = deps.updated(ModuleRef.JavaRef, Set())
   }
 
-  def apply(ref: ModuleRef, universe: Universe, layout: Layout)(implicit log: Log): Try[Target] = for {
+  def apply(ref: ModuleRef, hierarchy: Hierarchy, universe: Universe, layout: Layout)
+           (implicit log: Log)
+           : Try[Target] = for {
       entity    <- universe.entity(ref.projectId)
       module    <- entity.project(ref.moduleId)
       binaries  <- module.allBinaries.to[List].traverse(_.paths).map(_.flatten)
-      checkouts <- universe.checkout(ref, layout)
+      checkouts <- universe.checkout(ref, hierarchy, layout)
       sources   <- module.sources.to[List].traverse(_.dir(checkouts, layout))
     } yield Target(ref, module, entity, checkouts, sources, binaries )
 }

--- a/src/core/universe.scala
+++ b/src/core/universe.scala
@@ -24,26 +24,39 @@ import gastronomy._
 import scala.util._
 import scala.collection.immutable.TreeSet
 
-object Universe { def apply(): Universe = Universe(Map(), Map(), Map()) }
+object Universe { def apply(hierarchy: Hierarchy): Universe = Universe(hierarchy, Map(), Map(), Map()) }
 
 /** A Universe represents a the fully-resolved set of projects available in the layer */
-case class Universe(entities: Map[ProjectId, Entity],
+case class Universe(hierarchy: Hierarchy,
+                    projects: Map[ProjectId, Map[ProjectRef, Set[ImportPath]]],
                     repoSets: Map[RepoSetId, Set[RepoRef]],
                     imports: Map[ShortLayerRef, LayerEntity]) {
-  def ids: Set[ProjectId] = entities.keySet
-  def entity(id: ProjectId): Try[Entity] = entities.get(id).ascribe(ItemNotFound(id))
+  def ids: Set[ProjectId] = projects.keySet
+  
+  def importPaths(id: ProjectId): Try[Set[ImportPath]] = projects.get(id).ascribe(ItemNotFound(id)).flatMap {
+    case map if map.size == 1 => Success(map.values.head)
+    case map                  => Failure(ProjectConflict(map))
+  }
 
-  def apply(id: ProjectId): Try[Project] = entities.get(id).ascribe(ItemNotFound(id)).map(_.project)
+  def allProjects: Try[Set[Project]] = projects.keySet.traverse(apply(_))
+  def layer(id: ProjectId): Try[Layer] = importPaths(id).flatMap { is => hierarchy(is.head) }
+  def layer(id: ProjectRef): Try[Layer] = hierarchy(projects(id.id)(id).head)
+  def apply(id: ProjectRef): Try[Project] = layer(id).flatMap(_.projects.findBy(id.id))
+  def apply(id: ProjectId): Try[Project] = layer(id).flatMap(_.projects.findBy(id))
   def apply(id: RepoSetId): Try[Set[RepoRef]] = repoSets.get(id).ascribe(ItemNotFound(id))
   def apply(id: ShortLayerRef): Try[LayerEntity] = imports.get(id).ascribe(ItemNotFound(id))
 
-  def checkout(ref: ModuleRef, hierarchy: Hierarchy, layout: Layout)(implicit log: Log): Try[Snapshots] = for {
-    entity <- entity(ref.projectId)
-    module <- entity.project(ref.moduleId)
+  def projectRefs: Set[ProjectRef] =
+    projects.foldLeft(Set[ProjectRef]()) { case (acc, (_, map)) => acc ++ map.keySet }
 
-    repos  <- (module.externalSources ++ module.externalResources).to[List].groupBy(_.repoId).map {
-                case (k, v) => hierarchy(entity.imports.head).flatMap(_.repos.findBy(k).map(_ -> v))
-              }.sequence
+  def checkout(ref: ModuleRef, hierarchy: Hierarchy, layout: Layout)(implicit log: Log): Try[Snapshots] = for {
+    project <- apply(ref.projectId)
+    module  <- project(ref.moduleId)
+    layer   <- layer(ref.projectId)
+
+    repos   <- (module.externalSources ++ module.externalResources).to[List].groupBy(_.repoId).map {
+                 case (k, v) => layer.repos.findBy(k).map(_ -> v)
+               }.sequence
 
   } yield Snapshots(repos.map { case (repo, paths) =>
     val snapshot = Snapshot(repo.id, repo.remote, repo.localDir(layout), repo.commit, repo.branch,
@@ -53,19 +66,21 @@ case class Universe(entities: Map[ProjectId, Entity],
   }.toMap)
 
   def ++(that: Universe): Universe = {
-    val newEntities = that.entities.foldLeft(entities) { case (acc, (id, entity)) =>
-      acc.updated(id, acc.get(id).fold(entity) { e => e.copy(imports = e.imports ++ entity.imports) })
-    }
-
     val newRepoSets = that.repoSets.foldLeft(repoSets) { case (acc, (digest, set)) =>
       acc.updated(digest, acc.getOrElse(digest, Set()) ++ set)
+    }
+
+    val newProjects = that.projects.foldLeft(projects) { case (acc, (id, map)) =>
+      acc.updated(id, acc.get(id).fold(map)(map.foldLeft(_) { case (acc2, (ref, set)) =>
+        acc2.updated(ref, acc2.get(ref).fold(set)(_ ++ set))
+      }))
     }
 
     val newImports = that.imports.foldLeft(imports) { case (acc, (layerRef, entity)) =>
       acc.updated(layerRef, acc.getOrElse(layerRef, entity) + entity.imports)
     }
 
-    Universe(newEntities, newRepoSets, newImports)
+    Universe(hierarchy, newProjects, newRepoSets, newImports)
   }
 
   private[fury] def dependencies(ref: ModuleRef, layout: Layout): Try[Set[Dependency]] =
@@ -73,8 +88,8 @@ case class Universe(entities: Map[ProjectId, Entity],
 
   private[this] def transitiveDependencies(forbidden: Set[Dependency], dependency: Dependency, layout: Layout)
                                           : Try[Set[Dependency]] = for {
-    entity       <- entity(dependency.ref.projectId)
-    module       <- entity.project(dependency.ref.moduleId)
+    project      <- apply(dependency.ref.projectId)
+    module       <- project(dependency.ref.moduleId)
     dependencies  =  module.dependencies ++ module.compilerDependencies
     repeats       = dependencies.intersect(forbidden)
     _            <- if(repeats.isEmpty) ~() else Failure(CyclesInDependencies(repeats))
@@ -85,7 +100,7 @@ case class Universe(entities: Map[ProjectId, Entity],
   def clean(ref: ModuleRef, layout: Layout): Unit = layout.classesDir.delete().unit
 
   def apply(ref: ModuleRef): Try[Module] = for {
-    entity <- entity(ref.projectId)
-    module <- entity.project(ref.moduleId)
+    project <- apply(ref.projectId)
+    module  <- project(ref.moduleId)
   } yield module
 }

--- a/src/dependency/dependency.scala
+++ b/src/dependency/dependency.scala
@@ -223,7 +223,7 @@ case class PermissionCli(cli: Cli)(implicit log: Log) {
     module       <- tryModule
     hierarchy    <- layer.hierarchy()
     universe     <- hierarchy.universe
-    build        <- Build(universe, Dependency(module.ref(project)), layout)
+    build        <- Build(universe, Dependency(module.ref(project)), hierarchy, layout)
     permissions  <- permHashes.traverse(_.resolve(build.requiredPermissions))
     force        =  call(ForceArg).isSuccess
                          
@@ -271,7 +271,7 @@ case class PermissionCli(cli: Cli)(implicit log: Log) {
     permHashes    <- call(PermissionArg).map(_.map(PermissionHash(_)))
     hierarchy     <- layer.hierarchy()
     universe      <- hierarchy.universe
-    build         <- Build(universe, Dependency(module.ref(project)), layout)
+    build         <- Build(universe, Dependency(module.ref(project)), hierarchy, layout)
     permissions   <- permHashes.traverse(_.resolve(build.requiredPermissions))
     policy        =  Policy.read(log)
     newPolicy     =  policy.grant(Scope(scopeId, layout, project.id), permissions)

--- a/src/dependency/dependency.scala
+++ b/src/dependency/dependency.scala
@@ -86,10 +86,10 @@ case class DependencyCli(cli: Cli)(implicit log: Log) {
     hierarchy    <- layer.hierarchy()
     universe     <- hierarchy.universe
     
-    allRefs       = for(project <- tryProject; module <- tryModule)
+    allRefs       = for(project <- tryProject; module <- tryModule; otherRefs <- layer.deepModuleRefs(universe))
                     yield {
                       val fromOtherProjects = for {
-                        otherRef <- layer.deepModuleRefs(universe)
+                        otherRef <- otherRefs
                                 if !(otherRef.hidden || module.dependencies.map(_.ref).contains(otherRef))
                       } yield otherRef.id
                       val fromSameProject = for {

--- a/src/frontend/recovery.scala
+++ b/src/frontend/recovery.scala
@@ -31,12 +31,8 @@ object Recovery {
       err match {
         case EarlyCompletions() =>
           Done
-        case ProjectConflict(ps, left, right) =>
-          val projectIds = ps.toSeq.sortBy(_.key).map { x => msg"$x" }
-          val message = msg"Your dependency tree contains references to two or more conflicting projects: "
-          val beginning = projectIds.tail.foldLeft(message + projectIds.head)(_ + ", " + _)
-          val ending = msg". The first conflict was found between layers ${left} and ${right}"
-          cli.abort(msg"$beginning$ending")
+        case ProjectConflict(ids) =>
+          cli.abort(msg"Conflicting projects exist in the build.")
         case InitFailure() =>
           cli.abort(msg"Could not start the bloop server.")
         case WorkingDirectoryConflict(files) =>

--- a/src/frontend/recovery.scala
+++ b/src/frontend/recovery.scala
@@ -32,7 +32,11 @@ object Recovery {
         case EarlyCompletions() =>
           Done
         case ProjectConflict(ids) =>
-          cli.abort(msg"Conflicting projects exist in the build.")
+          val table = Tables().entities
+          val conflicts = Tables().show(table, cli.cols, ids, false, None, None: Option[String], "hash")
+          log.info(msg"Conflicting projects exist in the build:")
+          log.info(conflicts)
+          cli.abort(msg"You will need to unify these projects before you can continue.")
         case InitFailure() =>
           cli.abort(msg"Could not start the bloop server.")
         case WorkingDirectoryConflict(files) =>

--- a/src/model/exception.scala
+++ b/src/model/exception.scala
@@ -80,7 +80,6 @@ case class NotInitialized(dir: Path) extends FuryException
 case class OfflineException() extends FuryException
 case class ProjectAlreadyExists(project: ProjectId) extends FuryException
 case class PublishFailure() extends FuryException
-case class ProjectConflict(ids: Map[ProjectRef, Set[ImportPath]]) extends FuryException
 case class RemoteNotSynched(repo: RepoId, remote: String) extends FuryException
 case class RepoAlreadyForked(repo: RepoId, dir: Path) extends FuryException
 case class RepoDirty(repo: RepoId, changes: String) extends FuryException

--- a/src/model/exception.scala
+++ b/src/model/exception.scala
@@ -80,7 +80,7 @@ case class NotInitialized(dir: Path) extends FuryException
 case class OfflineException() extends FuryException
 case class ProjectAlreadyExists(project: ProjectId) extends FuryException
 case class PublishFailure() extends FuryException
-case class ProjectConflict(ids: Set[ProjectId], left: ImportPath, right: ImportPath) extends FuryException
+case class ProjectConflict(ids: Map[ProjectRef, Set[ImportPath]]) extends FuryException
 case class RemoteNotSynched(repo: RepoId, remote: String) extends FuryException
 case class RepoAlreadyForked(repo: RepoId, dir: Path) extends FuryException
 case class RepoDirty(repo: RepoId, changes: String) extends FuryException

--- a/src/model/ids.scala
+++ b/src/model/ids.scala
@@ -305,16 +305,17 @@ object ProjectRef {
   implicit val stringShow: StringShow[ProjectRef] = msgShow.show(_).string(Theme.NoColor)
   
   implicit val msgShow: MsgShow[ProjectRef] =
-    pr => msg"${pr.id}${'#'}${pr.digest}"
+    pr => msg"${pr.id}${pr.digest.fold(msg"") { d => msg"${'#'}${UserMsg { th => th.projectDark(d) }}" }}"
 
   implicit val parser: Parser[ProjectRef] = unapply(_)
 
   def unapply(value: String): Option[ProjectRef] = value.only {
-    case r"$id@([^#]+)\#$hash@([a-f0-9]{6})" => ProjectRef(ProjectId(id), hash)
+    case r"$id@([^#]+)\#$hash@([a-f0-9]{6})" => ProjectRef(ProjectId(id), Some(hash))
+    case r"$id@([^#]+)" => ProjectRef(ProjectId(id), None)
   }
 }
 
-case class ProjectRef(id: ProjectId, digest: String) extends Key(msg"project") {
+case class ProjectRef(id: ProjectId, digest: Option[String]) extends Key(msg"project") {
   def key: String = ProjectRef.stringShow.show(this)
 }
 

--- a/src/model/ids.scala
+++ b/src/model/ids.scala
@@ -301,8 +301,21 @@ case class LayerRef(key: String) extends Key(msg"layer") {
   def short: ShortLayerRef = ShortLayerRef(key.drop(2).take(8))
 }
 
-case class ProjectRef(digest: Digest) extends Key(msg"project") {
-  def key: String = digest.encoded[Hex]
+object ProjectRef {
+  implicit val stringShow: StringShow[ProjectRef] = msgShow.show(_).string(Theme.NoColor)
+  
+  implicit val msgShow: MsgShow[ProjectRef] =
+    pr => msg"${pr.id}${'#'}${pr.digest}"
+
+  implicit val parser: Parser[ProjectRef] = unapply(_)
+
+  def unapply(value: String): Option[ProjectRef] = value.only {
+    case r"$id@([^#]+)\#$hash@([a-f0-9]{6})" => ProjectRef(ProjectId(id), hash)
+  }
+}
+
+case class ProjectRef(id: ProjectId, digest: String) extends Key(msg"project") {
+  def key: String = ProjectRef.stringShow.show(this)
 }
 
 object ShortLayerRef {

--- a/src/model/ids.scala
+++ b/src/model/ids.scala
@@ -301,6 +301,10 @@ case class LayerRef(key: String) extends Key(msg"layer") {
   def short: ShortLayerRef = ShortLayerRef(key.drop(2).take(8))
 }
 
+case class ProjectRef(digest: Digest) extends Key(msg"project") {
+  def key: String = digest.encoded[Hex]
+}
+
 object ShortLayerRef {
   implicit val stringShow: StringShow[ShortLayerRef] = _.key
   implicit val msgShow: MsgShow[ShortLayerRef] = lr => UserMsg(_.layer(stringShow.show(lr)))

--- a/src/project/project.scala
+++ b/src/project/project.scala
@@ -29,7 +29,7 @@ import scala.collection.immutable.{SortedSet, TreeSet}
 case class ProjectCli(cli: Cli)(implicit val log: Log) extends CliApi {
   import Args._
 
-  lazy val getTable: Try[Tabulation[Entity]] = getLayer >> (_.main) >> (Tables().entities(_))
+  lazy val getTable: Try[Tabulation[Project]] = getLayer >> (_.main) >> (Tables().projects(_))
   
   implicit lazy val columnHints: ColumnArg.Hinter =
     ColumnArg.hint(getTable.map(_.headings.map(_.name.toLowerCase)))
@@ -40,7 +40,7 @@ case class ProjectCli(cli: Cli)(implicit val log: Log) extends CliApi {
 
   def list: Try[ExitStatus] = (cli -< ProjectArg -< RawArg -< ColumnArg).action { for {
     col     <- ~cli.peek(ColumnArg)
-    rows    <- universe >> (_.entities.values)
+    rows    <- getLayer >> (_.projects)
     project <- ~cliProject.toOption
     table   <- getTable >> (Tables().show(_, cli.cols, rows, has(RawArg), col, project >> (_.id), "project"))
     _       <- conf >> (_.focus()) >> (log.infoWhen(!has(RawArg))(_))

--- a/src/repo/universe.scala
+++ b/src/repo/universe.scala
@@ -138,7 +138,7 @@ case class UniverseApi(hierarchy: Hierarchy) {
       tmpHierarchy <- hierarchyWithoutProject(importPath, projectId)
       universe     <- tmpHierarchy.universe
       entity       <- universe.entities.get(projectId).ascribe(ItemNotFound(projectId))
-      hierarchy    <- entity.layers.to[List].foldLeft(Try(hierarchy)) { case (getHierarchy, (layerRef, _)) =>
+      hierarchy    <- entity.imports.to[List].foldLeft(Try(hierarchy)) { case (getHierarchy, layerRef) =>
                         for {
                           hierarchy <- getHierarchy
                           layer     <- hierarchy(layerRef)

--- a/src/source/source.scala
+++ b/src/source/source.scala
@@ -44,7 +44,7 @@ case class SourceCli(cli: Cli)(implicit log: Log) {
     module       <- tryModule
     hierarchy    <- layer.hierarchy()
     universe     <- hierarchy.universe
-    checkouts    <- universe.checkout(module.ref(project), layout)
+    checkouts    <- universe.checkout(module.ref(project), hierarchy, layout)
   } yield {
     val rows = module.sources.to[List]
     val table = Tables().sources(checkouts, layout)


### PR DESCRIPTION
This changes the structure of the projects in a `Universe` to allow access to a `Map` of projects by `ProjectId`, or an exact project by `ProjectRef`. If there is a unique definition for a project, the inner `Map` will have just a single entry, whereas conflicting project definitions will be represented by a map with multiple entries, from `ProjectRef` to `Set[ImportPath]`, which references the layers containing those projects.

This facilitates the `fury universe projects list` command which will list all the projects in the universe, including conflicts. However conflicting projects will be displayed, and must be referenced to by their project ID _and_ a six-character hex hash, something like, `magnolia#17fba9`.

This table of conflicting projects is also displayed when attempting to build while conflicts exist. For now, this just introduces the list of projects, though there will be some more PRs with changes that make it possible to manipulate the universe better.