### PR TITLE
`fury universe projects diff` menu item

### DIFF
--- a/src/core/args.scala
+++ b/src/core/args.scala
@@ -102,6 +102,7 @@ object Args {
 
   val ProjectArg = CliParam[ProjectId]('p', 'project, "specify a project")
   val ProjectRefArg = CliParam[ProjectRef]('p', 'project, "specify a project")
+  val AgainstProjectArg = CliParam[ProjectRef]('a', 'against, "specify a project to compare against")
   val OptArg = CliParam[OptId]('o', 'option, "compiler option")
   val PermissionArg = CliParam[List[String]]('P', 'permission, "permission entries")
   val PropArg = CliParam[JavaProperty]('D', 'property, "Java -D property")

--- a/src/core/cli.scala
+++ b/src/core/cli.scala
@@ -413,6 +413,8 @@ abstract class CliApi {
   lazy val universeRepos: Try[Set[RepoSetId]] = universe >> (_.repoSets.keySet)
   lazy val universeLayers: Try[Set[ShortLayerRef]] = universe >> (_.imports.keySet)
 
+  lazy val projectRefs: Try[Set[ProjectRef]] = universe >> (_.projectRefs)
+
   lazy val findUniqueRepoName: Try[RepoId] =
     (getLayer, newRepoName.orElse(repoNameFromPath)) >>= (_.repos.unique(_))
   
@@ -450,6 +452,8 @@ abstract class CliApi {
   implicit lazy val commitHints: CommitArg.Hinter = CommitArg.hint(allCommits)
   implicit lazy val repoSetHints: RepoSetArg.Hinter = RepoSetArg.hint(universeRepos)
   implicit lazy val layerRefHints: LayerRefArg.Hinter = LayerRefArg.hint(universeLayers)
+  implicit lazy val projectRefHints: ProjectRefArg.Hinter = ProjectRefArg.hint(projectRefs)
+  implicit lazy val againstProjectHints: AgainstProjectArg.Hinter = AgainstProjectArg.hint(projectRefs)
   
   implicit lazy val defaultCompilerHints: DefaultCompilerArg.Hinter =
     DefaultCompilerArg.hint((getLayer, getLayout) >> (Javac(8) :: _.compilerRefs(_).map(BspCompiler(_))))

--- a/src/frontend/menu.scala
+++ b/src/frontend/menu.scala
@@ -155,6 +155,7 @@ object FuryMenu {
         Action('update, msg"update repos universally", UniverseCli(_).repos.update, shortcut = 'u')
       ),
       Menu('projects, msg"view and modify projects", 'list, shortcut = 'p')(
+        Action('diff, msg"show differences between two projects", UniverseCli(_).projects.diff, shortcut = 'd'),
         Action('list, msg"show all projects", UniverseCli(_).projects.list, shortcut = 'l'),
         Action('proliferate, msg"update projects universally", UniverseCli(_).projects.proliferate, shortcut = 'p')
       ),

--- a/src/model/ids.scala
+++ b/src/model/ids.scala
@@ -305,13 +305,13 @@ object ProjectRef {
   implicit val stringShow: StringShow[ProjectRef] = msgShow.show(_).string(Theme.NoColor)
   
   implicit val msgShow: MsgShow[ProjectRef] =
-    pr => msg"${pr.id}${pr.digest.fold(msg"") { d => msg"${'#'}${UserMsg { th => th.projectDark(d) }}" }}"
+    pr => msg"${pr.id}${pr.digest.fold(msg"") { d => msg"${'@'}${UserMsg { th => th.projectDark(d) }}" }}"
 
   implicit val parser: Parser[ProjectRef] = unapply(_)
 
   def unapply(value: String): Option[ProjectRef] = value.only {
-    case r"$id@([^#]+)\#$hash@([a-f0-9]{6})" => ProjectRef(ProjectId(id), Some(hash))
-    case r"$id@([^#]+)" => ProjectRef(ProjectId(id), None)
+    case r"$id@([^@]+)\@$hash@([a-f0-9]{6})" => ProjectRef(ProjectId(id), Some(hash))
+    case r"$id@([^@]+)" => ProjectRef(ProjectId(id), None)
   }
 }
 


### PR DESCRIPTION
Introduces functionality for comparing one universal project to another. Due to the limitations of tab completion, the `#` symbol doesn't seem to be supported as a completion, so it's been swapped for `@` in project reference names.