### PR TITLE
Use `path"..."` instead of `Path("...")` for creating paths

### DIFF
--- a/src/build/rebuild.scala
+++ b/src/build/rebuild.scala
@@ -16,13 +16,12 @@
 */
 package fury
 
-import fury.core._, fury.text._, fury.model._
+import fury.core._, fury.text._, fury.model._, fury.io._
 
 import java.util.concurrent.atomic.AtomicBoolean
 
 import _root_.io.methvin.better.files.RecursiveFileMonitor
 import better.files.File
-import fury.io.Path
 import fury.utils.Threads
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -32,7 +31,7 @@ import scala.util._
 object Inotify {
   private var done: Boolean = false
   def check(watching: Boolean)(implicit log: Log): Try[Unit] = {
-    val maxQueuedWatchers = Path("/proc/sys/fs/inotify/max_user_watches")
+    val maxQueuedWatchers = path"/proc/sys/fs/inotify/max_user_watches"
     val count = if(watching && !done && maxQueuedWatchers.exists()) { for {
       lines <- maxQueuedWatchers.lines()
       count <- Try(lines.next().toInt)
@@ -43,7 +42,7 @@ object Inotify {
       log.warn(msg"Your system's ${ExecName("inotify")} settings may cause filewatching to fail.")
       log.warn(msg"Please append,")
       log.warn(msg"    fs.inotify.max_user_watches=524288")
-      log.warn(msg"to your ${Path("/etc/sysctl.conf")} file, and run,")
+      log.warn(msg"to your ${path"/etc/sysctl.conf"} file, and run,")
       log.warn(msg"    echo 524288 > ${maxQueuedWatchers.value}")
       log.warn(msg"")
     })

--- a/src/core/cli.scala
+++ b/src/core/cli.scala
@@ -252,7 +252,7 @@ class Cli(val stdout: java.io.PrintWriter,
     if(default.isDefined) result.recover { case _: exoskeleton.MissingArg => default.get } else result
   }
 
-  def pwd: Try[Path] = env.workDir.ascribe(FileNotFound(Path("/"))).map(Path(_))
+  def pwd: Try[Path] = env.workDir.ascribe(FileNotFound(path"/")).map(Path(_))
 
   lazy val newLayout: Try[Layout] = pwd.map { pwd => Layout(Path(env.variables("HOME")), pwd, env, pwd) }
 

--- a/src/core/external.scala
+++ b/src/core/external.scala
@@ -230,11 +230,11 @@ abstract class Installable(name: ExecName) extends Software(name) {
 object IpfsSoftware extends Installable(ExecName("ipfs")) {
   def installVersion = "0.6.0"
   def description: String = "InterPlanetary File System"
-  def website = Https(Path("ipfs.io"))
+  def website = Https(path"ipfs.io")
   def managedPath: Path = base / "go-ipfs" / "ipfs"
   
   def tarGz: Try[Uri] = {
-    def url(sys: String) = Https(Path("dist.ipfs.io") / "go-ipfs" / str"v$installVersion" /
+    def url(sys: String) = Https(path"dist.ipfs.io" / "go-ipfs" / str"v$installVersion" /
         str"go-ipfs_v${installVersion}_$sys.tar.gz")
     
     Installation.system.flatMap {
@@ -253,12 +253,12 @@ object IpfsSoftware extends Installable(ExecName("ipfs")) {
 object JavaSoftware extends Installable(ExecName("java")) {
   def installVersion = "8u242b08"
   def description = "Java™ SE Runtime Environment"
-  def website = Https(Path("openjdk.java.net"))
+  def website = Https(path"openjdk.java.net")
   def managedPath: Path = Installation.usrDir / "java" / "bin" / "java"
   def version(env: Environment): Option[String] = Option(System.getProperty("java.version"))
   
   def tarGz: Try[Uri] = {
-    def url(sys: String) = Https(Path("github.com") / "AdoptOpenJDK" / "openjdk8-binaries" / "releases" /
+    def url(sys: String) = Https(path"github.com" / "AdoptOpenJDK" / "openjdk8-binaries" / "releases" /
         "download" / str"OpenJDK8U-jdk_x64_${sys}_hotspot_${installVersion}.tar.gz")
     
     Installation.system.flatMap {
@@ -272,7 +272,7 @@ object JavaSoftware extends Installable(ExecName("java")) {
 object VsCodeSoftware extends Installable(ExecName("code")) {
   def installVersion = "1.42.1"
   def description = "Visual Studio Code"
-  def website = Https(Path("code.visualstudio.com"))
+  def website = Https(path"code.visualstudio.com")
 
   private def osDir(base: Path): Try[Path] = Installation.system.flatMap {
     case Linux(_) =>
@@ -290,8 +290,8 @@ object VsCodeSoftware extends Installable(ExecName("code")) {
   
   def tarGz: Try[Uri] = {
     Installation.system.flatMap {
-      case Linux(X64) => Success(Https(Path("go.microsoft.com") / "fwlink" / "?LinkID=620884"))
-      case MacOs(X64) => Success(Https(Path("go.microsoft.com") / "fwlink" / "?LinkID=620882"))
+      case Linux(X64) => Success(Https(path"go.microsoft.com" / "fwlink" / "?LinkID=620884"))
+      case MacOs(X64) => Success(Https(path"go.microsoft.com" / "fwlink" / "?LinkID=620882"))
       case other      => Failure(UnknownOs(other.toString))
     }
   }
@@ -303,7 +303,7 @@ object VsCodeSoftware extends Installable(ExecName("code")) {
 }
 
 object GitSoftware extends Software(ExecName("git")) {
-  def website = Https(Path("git-scm.com"))
+  def website = Https(path"git-scm.com")
   def description = "Git"
 
   def version(env: Environment): Option[String] = path(env).flatMap { execPath =>
@@ -312,7 +312,7 @@ object GitSoftware extends Software(ExecName("git")) {
 }
 
 object CcSoftware extends Software(ExecName("cc")) {
-  def website = Https(Path("gcc.gnu.org"))
+  def website = Https(path"gcc.gnu.org")
   def description = "C Compiler"
 
   def version(env: Environment): Option[String] = path(env).flatMap { execPath =>
@@ -321,7 +321,7 @@ object CcSoftware extends Software(ExecName("cc")) {
 }
 
 object GraalVmSoftware extends Installable(ExecName("native-image")) {
-  def website = Https(Path("www.graalvm.org"))
+  def website = Https(path"www.graalvm.org")
   def description = "GraalVM Native Image"
   def installVersion = "20.0.0"
 
@@ -330,7 +330,7 @@ object GraalVmSoftware extends Installable(ExecName("native-image")) {
   }
 
   def tarGz: Try[Uri] = {
-    def url(sys: String) = Https(Path("github.com") / "graalvm" / "graalvm-ce-builds" / "releases" /
+    def url(sys: String) = Https(path"github.com" / "graalvm" / "graalvm-ce-builds" / "releases" /
         "download" / str"vm-$installVersion" / str"graalvm-ce-java8-${sys}-amd64-$installVersion.tar.gz")
     
     Installation.system.flatMap {
@@ -345,7 +345,7 @@ object GraalVmSoftware extends Installable(ExecName("native-image")) {
 }
 
 object FurySoftware extends Software(ExecName("fury")) {
-  def website = Https(Path("propensive.com") / "fury")
+  def website = Https(path"propensive.com" / "fury")
   def description = "Fury"
   def version(env: Environment): Option[String] = Some(FuryVersion.current)
   override def path(env: Environment): Option[Path] = Some(Installation.binDir / "fury")

--- a/src/core/install.scala
+++ b/src/core/install.scala
@@ -54,9 +54,8 @@ object Install {
   private def fishInstall(env: Environment)(implicit log: Log): Try[Unit] =
     Try(log.warn(msg"Installation for ${ExecName("fish")} is not yet supported"))
 
-  private def iconDirs: List[Path] = List(16, 48, 128).map { s =>
-    Path("icons") / "hicolor" / str"${s}x${s}" / "apps" / "fury-icon.png"
-  }
+  private def iconDirs: List[Path] =
+    List(16, 48, 128).map { s => path"icons/hicolor" / str"${s}x${s}" / "apps" / "fury-icon.png" }
 
   private def desktopInstall(env: Environment)(implicit log: Log): Try[Unit] = for {
     _        <- ~log.info(msg"Installing handler for fury:// URLs")

--- a/src/core/layer.scala
+++ b/src/core/layer.scala
@@ -277,9 +277,9 @@ object Layer extends Lens.Partial[Layer] {
     (left, right) <- gitDir.mergeConflicts
     common        <- gitDir.mergeBase(left, right)
     _             <- ~log.warn(msg"The layer has merge conflicts")
-    leftSrc       <- gitDir.cat(left, Path(".fury/config"))
-    commonSrc     <- gitDir.cat(common, Path(".fury/config"))
-    rightSrc      <- gitDir.cat(right, Path(".fury/config"))
+    leftSrc       <- gitDir.cat(left, path".fury/config")
+    commonSrc     <- gitDir.cat(common, path".fury/config")
+    rightSrc      <- gitDir.cat(right, path".fury/config")
     leftConf      <- Ogdl.read[FuryConf](leftSrc, identity(_))
     commonConf    <- Ogdl.read[FuryConf](commonSrc, identity(_))
     rightConf     <- Ogdl.read[FuryConf](rightSrc, identity(_))

--- a/src/core/maven.scala
+++ b/src/core/maven.scala
@@ -37,7 +37,7 @@ object MavenCentral {
     val httpQuery = Query("q" -> query, "core" -> "gav", "wt" -> "json", "rows" -> "100")
 
     for {
-      string <- Http.get(Https(Path("search.maven.org") / "solrsearch" / "select", httpQuery).key,
+      string <- Http.get(Https(path"search.maven.org/solrsearch/select", httpQuery).key,
                     Set()).to[Try]
 
       json   <- Json.parse(new String(string, "UTF-8")).to[Try]

--- a/src/core/sourceRepo.scala
+++ b/src/core/sourceRepo.scala
@@ -42,7 +42,7 @@ object Repo extends Lens.Partial[Repo] {
     dest      <- Try((Xdg.runtimeDir / str"${repoId.key}.bak").uniquify())
     files     <- gitDir.trackedFiles
     _         <- ~log.info(msg"Moving working directory contents to $dest")
-    _         <- files.filter(_ != Path(".fury")).traverse { f => f.in(layout.baseDir).moveTo(f.in(dest)) }
+    _         <- files.filter(_ != path".fury").traverse { f => f.in(layout.baseDir).moveTo(f.in(dest)) }
     _         <- (layout.baseDir / ".git").moveTo(dest / ".git")
     _         <- ~log.info(msg"Moved ${files.length + 1} files to ${dest}")
   } yield Repo(repoId, remote, branch, commit, None)
@@ -116,7 +116,7 @@ case class Repo(id: RepoId, remote: Remote, branch: Branch, commit: Commit, loca
     removed   <- local.flatMap(_.local).fold(Try(List[Path]()))(GitDir(_)(layout.env).trackedFiles)
     bareRepo  <- remote.fetch(layout)
     files     <- bareRepo.lsRoot(commit)
-    remaining <- Try((current -- removed) - Path(".fury/config"))
+    remaining <- Try((current -- removed) - path".fury/config")
   } yield remaining.intersect(files.to[Set]).to[List]
 
   def doCleanCheckout(layout: Layout)(implicit log: Log): Try[Unit] = for {

--- a/src/io-test/pathtests.scala
+++ b/src/io-test/pathtests.scala
@@ -36,7 +36,7 @@ object PathTests extends Suite() {
     }.assert(_.isSuccess)
 
     test("fail to mark a system file as executable") {
-      val file = Path("/etc") / "passwd"
+      val file = path"/etc/passwd"
       file.touch()
       file.setExecutable(true)
     }.assert(_.isFailure)

--- a/src/io/package.scala
+++ b/src/io/package.scala
@@ -1,0 +1,25 @@
+/*
+
+    Fury, version 0.17.0. Copyright 2018-20 Jon Pretty, Propensive OÜ.
+
+    The primary distribution site is: https://propensive.com/
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+    compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License is
+    distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and limitations under the License.
+
+*/
+package fury
+
+import contextual._
+
+package object io {
+  implicit class PathContext(sc: StringContext) {
+    val path = Prefix(PathInterpolator, sc)
+  }
+}

--- a/src/model/layout.scala
+++ b/src/model/layout.scala
@@ -51,17 +51,14 @@ object Xdg {
     def paths: Option[List[Path]] = variable.map(_.split(":").to[List].map(Path(_)))
   }
   
-  val home: Path = Option(System.getenv("HOME")).map(Path(_)).getOrElse(Path("/"))
+  val home: Path = Option(System.getenv("HOME")).map(Path(_)).getOrElse(path"/")
   val ipfsRepo: Path = Option(System.getenv("IPFS_PATH")).map(Path(_)).getOrElse(home / ".ipfs")
   val cacheHome: Path = Var("CACHE_HOME").path.getOrElse(home / ".cache")
   val dataHome: Path = Var("DATA_HOME").path.getOrElse(home / ".local" / "share")
-  
-  val dataDirs: List[Path] = Var("DATA_DIRS").paths.getOrElse(List(Path("/usr/local/share"),
-      Path("/usr/share")))
-  
+  val dataDirs: List[Path] = Var("DATA_DIRS").paths.getOrElse(List(path"/usr/local/share", path"/usr/share"))
   val configHome: Path = Var("CONFIG_HOME").path.getOrElse(home / ".config")
-  val configDirs: List[Path] = Var("CONFIG_DIRS").paths.getOrElse(List(Path("/etc/xdg")))
-  val runtimeDir: Path = Var("RUNTIME_DIR").path.getOrElse(Path("/tmp"))
+  val configDirs: List[Path] = Var("CONFIG_DIRS").paths.getOrElse(List(path"/etc/xdg"))
+  val runtimeDir: Path = Var("RUNTIME_DIR").path.getOrElse(path"/tmp")
   val docsDir: Path = Var("DOCUMENTS_DIR").path.getOrElse(home / "Documents")
 
   val pathEnv: List[Path] = Option(System.getenv("PATH")).map { str => str.split(":").to[List].map(Path(_))

--- a/src/repo/repo.scala
+++ b/src/repo/repo.scala
@@ -86,7 +86,7 @@ case class RepoCli(cli: Cli)(implicit val log: Log) extends CliApi {
  
                    _      <- (gitDir.dir.childPaths.flatMap { f =>
                                if((f.parent.parent / f.name).exists()) List(Path(f.name)) else Nil
-                             }).filterNot(_ == Path(".fury")) match {
+                             }).filterNot(_ == path".fury") match {
                                case Nil => Success(())
                                case fs  => Failure(WorkingDirectoryConflict(fs))
                              }


### PR DESCRIPTION
This provides some checking of the validity of hardcoded filenames at compile time, using Contextual.