### PR TITLE
Integration tests for compiler plugins

### DIFF
--- a/src/model/ids.scala
+++ b/src/model/ids.scala
@@ -1004,7 +1004,7 @@ object OptId {
   implicit val parser: Parser[OptId] = unapply(_)
   
   def unapply(value: String): Option[OptId] =
-    value.only { case r"[a-zA-Z0-9\-\.\:]+" => OptId(value) }
+    value.only { case r"[\w/\-\.\:]+" => OptId(value) }
 }
 
 case class OptId(key: String) extends Key(msg"option")

--- a/test/passing/plugin-jar/check
+++ b/test/passing/plugin-jar/check
@@ -1,0 +1,13 @@
+Initialized an empty layer
+Set current project to scala
+Set current module to compiler
+Set current project to plugins
+Setting default compiler for plugins to scala/compiler
+Set current module to kind-projector
+Set current project to hello-world
+Setting default compiler for hello-world to scala/compiler
+Set current module to app
+Starting compilation of module hello-world/app
+Successfully compiled module hello-world/app
+Hello kind-projector!
+0

--- a/test/passing/plugin-jar/description
+++ b/test/passing/plugin-jar/description
@@ -1,0 +1,1 @@
+Use a scalac plugin supplied as a binary dependency

--- a/test/passing/plugin-jar/script
+++ b/test/passing/plugin-jar/script
@@ -1,0 +1,17 @@
+fury layer init
+fury project add -n scala
+fury module add -n compiler -t compiler -C scala-lang.org:scala-compiler:2.12.8
+fury binary add -b org.scala-lang:scala-compiler:2.12.8
+
+fury project add -n plugins
+fury module add -n kind-projector -c scala/compiler -t plugin -M d_m.KindProjector -P kind-projector
+fury binary add -b org.typelevel:kind-projector_2.12.8:0.11.0
+fury option add -o language:higherKinds -P
+
+fury project add -n hello-world
+fury module add -n app -c scala/compiler -t app -M app.Main
+fury dependency add -d plugins/kind-projector
+fury source add -s src
+
+fury build run --output linear
+echo $?

--- a/test/passing/plugin-jar/src/app.scala
+++ b/test/passing/plugin-jar/src/app.scala
@@ -1,0 +1,22 @@
+package app
+
+object Main {
+
+  // Copied from https://github.com/typelevel/kind-projector/blob/master/src/test/scala/bounds.scala
+  trait Leibniz[-L, +H >: L, A >: L <: H, B >: L <: H]
+
+  object Test {
+    trait Foo
+    trait Bar extends Foo
+
+    def outer[A >: Bar <: Foo] = {
+      def test[F[_ >: Bar <: Foo]] = "Hello kind-projector!"
+      test[λ[`b >: Bar <: Foo` => Leibniz[Bar, Foo, A, b]]]
+    }
+  }
+
+  def main(args: Array[String]): Unit = {
+    println(Test.outer)
+  }
+}
+

--- a/test/passing/plugin-source/check
+++ b/test/passing/plugin-source/check
@@ -1,0 +1,21 @@
+Initialized an empty layer
+Set current project to scala
+Set current module to compiler
+Set current project to hello-world
+Setting default compiler for hello-world to scala/compiler
+Set current module to divbyzero
+1
+Xplugin:/.fury/classes/hello-world_divbyzero
+0
+Set current module to app
+Starting compilation of module hello-world/divbyzero
+Successfully compiled module hello-world/divbyzero
+Starting compilation of module hello-world/divbyzero
+Successfully compiled module hello-world/divbyzero
+Starting compilation of module hello-world/app
+[E] hello-world/app>local:src/app.scala:6:23
+| definitely division by zero
+| val amount = five / 0
+Compilation of module hello-world/app failed
+One of the compile tasks failed. Check the logs for details.
+1

--- a/test/passing/plugin-source/description
+++ b/test/passing/plugin-source/description
@@ -1,0 +1,1 @@
+Compile a scalac plugin from source and use it in another module

--- a/test/passing/plugin-source/plugin/DivByZero.scala
+++ b/test/passing/plugin-source/plugin/DivByZero.scala
@@ -1,0 +1,34 @@
+package localhost
+
+import scala.tools.nsc
+import nsc.Global
+import nsc.Phase
+import nsc.plugins.Plugin
+import nsc.plugins.PluginComponent
+
+class DivByZero(val global: Global) extends Plugin {
+  // Copied from https://docs.scala-lang.org/overviews/plugins/index.html
+
+  import global._
+
+  val name = "divbyzero"
+  val description = "checks for division by zero"
+  val components = List[PluginComponent](Component)
+
+  private object Component extends PluginComponent {
+    val global: DivByZero.this.global.type = DivByZero.this.global
+    val runsAfter = List[String]("refchecks")
+    val phaseName = DivByZero.this.name
+    def newPhase(_prev: Phase) = new DivByZeroPhase(_prev)
+    class DivByZeroPhase(prev: Phase) extends StdPhase(prev) {
+      override def name = DivByZero.this.name
+      def apply(unit: CompilationUnit): Unit = {
+        for ( tree @ Apply(Select(rcvr, nme.DIV), List(Literal(Constant(0)))) <- unit.body
+              if rcvr.tpe <:< definitions.IntClass.tpe)
+        {
+          global.reporter.error(tree.pos, "definitely division by zero")
+        }
+      }
+    }
+  }
+}

--- a/test/passing/plugin-source/script
+++ b/test/passing/plugin-source/script
@@ -1,0 +1,19 @@
+fury layer init
+fury project add -n scala
+fury module add -n compiler -t compiler -C scala-lang.org:scala-compiler:2.12.8
+fury binary add -b org.scala-lang:scala-compiler:2.12.8
+
+fury project add -n hello-world
+fury module add -n divbyzero -c scala/compiler -t plugin -M localhost.DivByZero -P divbyzero
+fury source add -s plugin
+fury option list --raw | wc -w
+fury option list --raw | sed "s#$PWD##"
+fury option remove -o "Xplugin:$PWD/.fury/classes/hello-world_divbyzero"
+fury option list --raw | wc -w
+
+fury module add -n app -c scala/compiler -t app -M app.Main
+fury dependency add -d divbyzero
+fury source add -s src
+
+fury build run --output linear
+echo $?

--- a/test/passing/plugin-source/src/app.scala
+++ b/test/passing/plugin-source/src/app.scala
@@ -1,0 +1,10 @@
+package app
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    val five = 5
+    val amount = five / 0
+    println(amount)
+  }
+}
+


### PR DESCRIPTION
I had to make the unapply regex for `OptId` more permissive, because a plugin module defines an option that looks like this:
```
┌───┬─────────────────────────────────────────────────────┬────────────┬────────┐
│   │ Param                                               │ Persistent │ Origin │
├───┼─────────────────────────────────────────────────────┼────────────┼────────┤
│ + │ Xplugin:/base/dir/.fury/classes/project-name_module │ Yes        │ plugin │
└───┴─────────────────────────────────────────────────────┴────────────┴────────┘

```
This option is inherited by all modules that depend on the plugin, and it could be neither removed nor added back.