### PR TITLE
Fix bad root/empty pointers

### DIFF
--- a/src/core/args.scala
+++ b/src/core/args.scala
@@ -75,6 +75,7 @@ object Args {
   val IntransitiveArg = CliParam[Unit]('I', 'intransitive,
       "specify if this dependency should not be included transitively")
 
+  val IgnoreArg = CliParam[Unit]('I', 'ignore, "ignore layer errors")
   val KeyArg = CliParam[String]('k', 'key, "GPG key")
   val ImportArg = CliParam[LayerName]('l', 'layer, "specify an external layer to import")
   val ImportIdArg = CliParam[ImportId]('i', 'import, "specify an import by ID")

--- a/src/core/cli.scala
+++ b/src/core/cli.scala
@@ -289,7 +289,7 @@ class Cli(val stdout: java.io.PrintWriter,
     pw.write(script)
     pw.write("\n")
     pw.close()
-    Log.log(Pid(0)).info(msg"Exporting temporary script file to ${scriptFile}")
+    Log().info(msg"Exporting temporary script file to ${scriptFile}")
     Continuation
   }
 

--- a/src/core/logging.scala
+++ b/src/core/logging.scala
@@ -102,10 +102,7 @@ object Log {
   private lazy val global: LogStyle = {
     val initDate = LocalDate.now()
     var cached: Int = initDate.getDayOfMonth
-    
-    def create(date: LocalDate) =
-      new PrintWriter(new BufferedWriter(new FileWriter(path(date).javaFile, true)))
-    
+    def create(date: LocalDate) = new PrintWriter(new BufferedWriter(new FileWriter(path(date).javaFile, true)))
     def path(date: LocalDate) = Installation.logsDir.extant() / str"${date.toString}.log"
     var printWriter: PrintWriter = create(initDate)
     def update(date: LocalDate): Unit = printWriter = create(date)

--- a/src/core/logging.scala
+++ b/src/core/logging.scala
@@ -97,6 +97,7 @@ object Log {
   val Fail = 4
 
   private val logFiles: HashMap[Path, LogStyle] = HashMap()
+  private lazy val base: Log = new Log(global, Pid(0))
   
   private lazy val global: LogStyle = {
     val initDate = LocalDate.now()
@@ -118,6 +119,7 @@ object Log {
     LogStyle(get, Some(true), true, true, false, Theme.Full, Note, autoflush = false)
   }
 
+  def apply(): Log = base
   def log(pid: Pid): Log = new Log(global, pid)
 }
 

--- a/src/core/uniqueness.scala
+++ b/src/core/uniqueness.scala
@@ -19,29 +19,31 @@ package fury.core
 sealed trait Uniqueness[Ref, Origin] {
   def +(other: Uniqueness[Ref, Origin]): Uniqueness[Ref, Origin]
   def allOrigins: Set[Origin]
+  def one: Option[Origin]
+  def any: Option[Origin]
 }
 
 object Uniqueness {
   case class Unique[Ref, Origin](ref: Ref, origins: Set[Origin]) extends Uniqueness[Ref, Origin] {
-
     override def +(other: Uniqueness[Ref, Origin]): Uniqueness[Ref, Origin] = other match {
       case Unique(ref, origins) if ref == this.ref => Unique(ref, this.origins ++ origins)
       case Ambiguous(origins) => Ambiguous(origins ++ this.origins.map(i => i -> this.ref))
     }
 
     override def allOrigins: Set[Origin] = origins
-
+    def one: Option[Origin] = Some(origins.head)
+    def any: Option[Origin] = None
   }
 
   case class Ambiguous[Ref, Origin] private[Uniqueness](origins: Map[Origin, Ref]) extends Uniqueness[Ref, Origin] {
-
     override def +(other: Uniqueness[Ref, Origin]): Uniqueness[Ref, Origin] = other match {
       case Unique(ref, origins) => Ambiguous(this.origins ++ origins.map(i => i -> ref))
       case Ambiguous(origins) => Ambiguous(this.origins ++ origins)
     }
 
     override def allOrigins: Set[Origin] = origins.keySet
-
+    def one: Option[Origin] = None
+    def any: Option[Origin] = Some(origins.head._1)
   }
 }
 

--- a/src/frontend/recovery.scala
+++ b/src/frontend/recovery.scala
@@ -101,7 +101,7 @@ You can grant these permissions with,
         case CannotUndo() =>
           cli.abort(msg"""The previous action cannot be undone.""")
         case UnresolvedModules(refs) =>
-          cli.abort(msg"""Some modules contain references to other modules which do not exist.""")
+          cli.abort(msg"""The layer refers to modules which cannot be resolved: ${refs.toString}""")
         case PublishFailure() =>
           cli.abort(msg"""The server was not able to publish this layer.""")
         case LayerContainsLocalSources(refs) =>
@@ -242,9 +242,8 @@ You can grant these permissions with,
             s"\n$e\n${rootCause(e).getStackTrace.to[List].map(_.toString).join("    at ", "\n    at ", "")}"
           val result = for {
             layout <- cli.layout
-            gLog   <- ~Log.log(Pid(0))
-            _      <- ~gLog.fail(errorString)
-            _      <- ~gLog.await()
+            _      <- ~Log().fail(errorString)
+            _      <- ~Log().await()
           } yield
             cli.abort(msg"An unexpected error occurred:$errorString")
 

--- a/src/model/ids.scala
+++ b/src/model/ids.scala
@@ -131,7 +131,7 @@ case class Pointer(path: String) {
     case _ => Nil
   }
 
-  def /(importId: ImportId): Pointer = Pointer(s"$path/${importId.key}")
+  def /(importId: ImportId): Pointer = Pointer(if(isEmpty) str"/${importId.key}" else s"$path/${importId.key}")
   def tail: Pointer = Pointer(parts.tail.map(_.key).mkString("/", "/", ""))
   def init: Pointer = Pointer(parts.init.map(_.key).mkString("/", "/", ""))
   def head: ImportId = parts.head

--- a/src/repo/universe.scala
+++ b/src/repo/universe.scala
@@ -159,7 +159,7 @@ case class UniverseApi(hierarchy: Hierarchy) {
       newLayerRef <- Layer.resolve(importName)
       pub         <- Layer.published(importName)
       newLayer    <- Layer.get(newLayerRef, pub)
-      _           <- newLayer.verify(false, Pointer.Root)
+      _           <- newLayer.verify(false, false, Pointer.Root)
       
       hierarchy   <- hierarchy.updateAll(layerEntity.imports) { (layer, imp) =>
                        val newImport = imp.copy(layerRef = newLayerRef, remote = pub)


### PR DESCRIPTION
This PR fixes a problem that became apparent when cloning or importing a layer that module references couldn't be resolved. Somewhere, we were appending an import ID to a root path, with a `/` between them, which resulted in a pointer beginning with `//`, which then failed to match.

This changes the definition of `def /` so that it first checks if it's appending to an empty layer, and omits the `/` in those cases.

I also provided a more convenient way of logging to the global log (without a PID) using `Log().info` or `Log().note` etc. I've also added the `--ignore`/`-I` flag to `layer clone` and `layer import` which permits imports even when they're failing, though this should only be useful temporarily for working around bugs like this, because publishing of broken layers is still impossible.