### PR TITLE
Proof of concept for conditional arguments

### DIFF
--- a/src/core/cli.scala
+++ b/src/core/cli.scala
@@ -308,6 +308,13 @@ class Cli(val stdout: java.io.PrintWriter,
     Cli(stdout, args, command, newHints :: optCompletions, env, pid)
   }
 
+  def -?<(arg: CliParam, condition: Try[Boolean])
+        (implicit hinter: arg.Hinter, stringShow: StringShow[arg.Type], descriptor: Descriptor[arg.Type])
+  : Cli { type Hinted <: cli.Hinted with arg.type } = condition match {
+    case Success(true) => -<(arg)
+    case _ => Cli(stdout, args, command, optCompletions, env, pid)
+  }
+
   def hint(arg: CliParam): Success[Cli { type Hinted <: cli.Hinted with arg.type }] =
     Success(Cli(stdout, args, command, Cli.OptCompletion(arg, "()"):: optCompletions, env, pid)) 
 


### PR DESCRIPTION
## Example
```
% fury module update --
--compiler  -- specify a compiler
--hidden    -- hide this module
--module    -- specify a module
--name      -- specify a name for the module
--project   -- specify a project
--type      -- Type of module (lib, app, plugin, compiler, bench)
```
```
% fury module update --type app --
--compiler  -- specify a compiler
--hidden    -- hide this module
--main      -- specify a main class
--module    -- specify a module
--name      -- specify a name for the module
--project   -- specify a project
--timeout   -- stop application if it is still running after this time (seconds)
```
```
% fury module update --type compiler --
--compiler       -- specify a compiler
--compiler-spec  -- specify a specification for the compiler in the form <organization>:<compiler ID>:<version>
--hidden         -- hide this module
--module         -- specify a module
--name           -- specify a name for the module
--project        -- specify a project
--repl           -- REPL class to use for console

```
## Outstanding problems
* The conditional argument is always accepted regardless of the condition. Depending on the implementation of the command, this argument might be ignored, produce an error, or produce an invalid result (e. g. define a timeout for a library module).
* The syntax might look bloated when the conditions are complex.

This pull request is related to the issue #1498.