### PR TITLE
Keep the information about all origins when ambiguous project references are detected

### DIFF
--- a/src/core-test/tests.scala
+++ b/src/core-test/tests.scala
@@ -22,5 +22,6 @@ object CoreTests extends Suite() {
   def run(test: Runner): Unit = {
     test.suite("DAG tests")(DagTest.run)
     test.suite("Remote name tests")(RemoteNameTest.run)
+    test.suite("Uniqueness tests")(UniquenessTest.run)
   }
 }

--- a/src/core-test/testuniqueness.scala
+++ b/src/core-test/testuniqueness.scala
@@ -1,0 +1,47 @@
+/*
+
+    Fury, version 0.17.0. Copyright 2018-20 Jon Pretty, Propensive OÜ.
+
+    The primary distribution site is: https://propensive.com/
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+    compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License is
+    distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and limitations under the License.
+
+*/
+package fury.test
+
+import probably._
+
+import fury.core._
+import fury.core.Uniqueness._
+
+object UniquenessTest extends Suite() {
+
+  private[this] case class Ref(id: String)
+  private[this] case class Origin(id: String)
+
+  def run(test: Runner): Unit = {
+    test("Unique + Unique = Unique") {
+      uniq("foo", "bar") + uniq("foo", "baz")
+    }.assert(_ == uniq("foo", "bar", "baz"))
+
+    test("Unique + Unique = Ambiguous") {
+      uniq("foo", "bar") + uniq("quux", "baz")
+    }.assert(_ == amb("bar" -> "foo", "baz" -> "quux"))
+
+    test("Ambiguous + Unique = Ambiguous") {
+      uniq("foo", "bar") + uniq("quux", "baz") + uniq("foo", "zzz")
+    }.assert(_ == amb("bar" -> "foo", "baz" -> "quux", "zzz" -> "foo"))
+
+  }
+
+  private[this] def uniq(ref: String, origins: String*): Uniqueness[Ref, Origin] = Unique(Ref(ref), origins.map(Origin(_)).to[Set])
+  private[this] def amb(origins: (String, String)*): Uniqueness[Ref, Origin] = Ambiguous(origins.toMap.map { case (o, r) => (Origin(o), Ref(r)) })
+
+}

--- a/src/core/uniqueness.scala
+++ b/src/core/uniqueness.scala
@@ -27,7 +27,10 @@ object Uniqueness {
   case class Unique[Ref, Origin](ref: Ref, origins: Set[Origin]) extends Uniqueness[Ref, Origin] {
     override def +(other: Uniqueness[Ref, Origin]): Uniqueness[Ref, Origin] = other match {
       case Unique(ref, origins) if ref == this.ref => Unique(ref, this.origins ++ origins)
-      case Unique(ref, origins)                    => Ambiguous(origins.map { k => k -> ref }.toMap)
+      case Unique(ref, origins) =>
+        val theseOrigins = this.origins.map { k => k -> this.ref }
+        val thoseOrigins = origins.map { k => k -> ref }
+        Ambiguous((theseOrigins ++ thoseOrigins).toMap)
       case Ambiguous(origins) => Ambiguous(origins ++ this.origins.map(i => i -> this.ref))
     }
 

--- a/test/passing/projects-proliferate/check
+++ b/test/passing/projects-proliferate/check
@@ -1,0 +1,32 @@
+Initialized an empty layer
+Set current project to scala
+Set current module to compiler
+Set current project to hello-world
+Setting default compiler for hello-world to scala/compiler
+Set current module to app
+IPFS ref 1: fury://QmU2Asaiwr5w3mUG6R1QJjVNpTvtKTFKAEjJCr4JUdU2TF
+Initialized an empty layer
+Set current project to scala
+Set current module to compiler
+Set current project to hello-world
+Setting default compiler for hello-world to scala/compiler
+Set current module to app
+IPFS ref 2: fury://QmbFW5SEsDsLrrxAriUgQHZXKEQXzXZN9ZZmADtVGwMvT4
+Initialized an empty layer
+Checking that no modules reference local sources
+Checking that no project names conflict
+Checking that all module references resolve
+0
+Checking that no modules reference local sources
+Checking that no project names conflict
+Checking that all module references resolve
+0
+U2Asaiwr
+bFW5SEsD
+hello-world@8803c7
+hello-world@c0dd15
+scala
+U2Asaiwr
+U2Asaiwr
+hello-world
+scala

--- a/test/passing/projects-proliferate/description
+++ b/test/passing/projects-proliferate/description
@@ -1,0 +1,1 @@
+Resolve a project reference conflict by updating all the instances of the same project across the import tree

--- a/test/passing/projects-proliferate/script
+++ b/test/passing/projects-proliferate/script
@@ -1,0 +1,46 @@
+mkdir layer1
+cd layer1
+
+fury layer init
+
+fury project add -n scala
+fury module add -n compiler -t compiler -C scala-lang.org:scala-compiler:2.12.8
+fury binary add -b org.scala-lang:scala-compiler:2.12.8
+
+fury project add -n hello-world
+fury module add -n app -c scala/compiler -t app -M Hello1
+#fury source add -s src
+
+IPFSREF1=$(fury layer share -F --raw)
+echo IPFS ref 1: $IPFSREF1
+
+cd ..
+
+mkdir layer2
+cd layer2
+
+fury layer init
+
+fury project add -n scala
+fury module add -n compiler -t compiler -C scala-lang.org:scala-compiler:2.12.8
+fury binary add -b org.scala-lang:scala-compiler:2.12.8
+
+fury project add -n hello-world
+fury module add -n app -c scala/compiler -t app -M Hello2
+#fury source add -s src
+
+IPFSREF2=$(fury layer share -F --raw)
+echo IPFS ref 2: $IPFSREF2
+
+cd ..
+
+fury layer init
+fury layer import -l $IPFSREF1 --name platform1
+echo $?
+fury layer import -l $IPFSREF2 --name platform2
+echo $?
+fury layer list --raw --column ref
+fury universe projects list --raw
+fury universe projects proliferate -l / -p hello-world@8803c7
+fury layer list --raw --column ref
+fury universe projects list --raw


### PR DESCRIPTION
Fixes #1501.