### PR TITLE
Renamed LayerEntity to LayerProvenance.

### DIFF
--- a/src/core/layer.scala
+++ b/src/core/layer.scala
@@ -58,7 +58,7 @@ case class Layer(version: Int,
     hierarchy = hierarchy,
     projects = projects.map { project => project.id -> Uniqueness.Unique(project.projectRef, Set(path)) }.toMap,
     repoSets = repos.groupBy(_.commit.repoSetId).mapValues(_.map(_.ref(path))),
-    imports = imports.map { i => i.layerRef.short -> LayerEntity(i.layerRef.short, Map(path -> i)) }.toMap
+    imports = imports.map { i => i.layerRef.short -> LayerProvenance(i.layerRef.short, Map(path -> i)) }.toMap
   )
 
   def checkinSources(repoId: RepoId): Layer = copy(projects = projects.map { project =>

--- a/src/core/tables.scala
+++ b/src/core/tables.scala
@@ -243,10 +243,10 @@ case class Tables() {
     Heading("Layers", _._2.map(_.layer: UserMsg).reduce { (l, r) => l+"\n"+r })
   )
   
-  val layerRefs: Tabulation[LayerEntity] = Tabulation(
+  val layerRefs: Tabulation[LayerProvenance] = Tabulation(
     Heading("Import", _.ref),
     Heading("IDs", _.ids),
     Heading("Remotes", _.published),
-    Heading("Layers", _.imports.keySet.map { v => v: UserMsg }.reduce { (l, r) => l+"\n"+r })
+    Heading("Imported by", _.imports.keySet.map { v => v: UserMsg }.reduce { (l, r) => l+"\n"+r })
   )
 }

--- a/src/core/universe.scala
+++ b/src/core/universe.scala
@@ -33,7 +33,7 @@ object Universe {
 case class Universe(hierarchy: Hierarchy,
                     projects: Map[ProjectId, Uniqueness[ProjectRef, Pointer]],
                     repoSets: Map[RepoSetId, Set[RepoRef]],
-                    imports: Map[ShortLayerRef, LayerEntity]) {
+                    imports: Map[ShortLayerRef, LayerProvenance]) {
   def ids: Set[ProjectId] = projects.keySet
 
   import Uniqueness._
@@ -70,7 +70,7 @@ case class Universe(hierarchy: Hierarchy,
   def apply(id: ProjectRef): Try[Project] = layer(id).flatMap(_.projects.findBy(id.id))
   def apply(id: ProjectId): Try[Project] = layer(id).flatMap(_.projects.findBy(id))
   def apply(id: RepoSetId): Try[Set[RepoRef]] = repoSets.get(id).ascribe(ItemNotFound(id))
-  def apply(id: ShortLayerRef): Try[LayerEntity] = imports.get(id).ascribe(ItemNotFound(id))
+  def apply(id: ShortLayerRef): Try[LayerProvenance] = imports.get(id).ascribe(ItemNotFound(id))
   def apply(ref: ModuleRef): Try[Module] = apply(ref.projectId) >>= (_(ref.moduleId))
   def clean(ref: ModuleRef, layout: Layout): Unit = layout.classesDir.delete().unit
 

--- a/src/model/ids.scala
+++ b/src/model/ids.scala
@@ -331,7 +331,7 @@ object ShortLayerRef {
 
 case class ShortLayerRef(key: String) extends Key(msg"layer")
 
-case class LayerEntity(ref: ShortLayerRef, imports: Map[Pointer, Import]) {
+case class LayerProvenance(ref: ShortLayerRef, imports: Map[Pointer, Import]) {
   def +(newImports: Map[Pointer, Import]) = copy(imports = imports ++ newImports)
   def ids: Set[ImportId] = imports.values.map(_.id).to[Set]
   def published: Set[PublishedLayer] = imports.values.flatMap(_.remote).to[Set]


### PR DESCRIPTION
I think the new name much better describes the purpose of this class, as well as the relation between the layer hash and the collection of imports associated with it.