### PR TITLE
Select version when importing a layer

### DIFF
--- a/src/build/build.scala
+++ b/src/build/build.scala
@@ -661,13 +661,15 @@ case class LayerCli(cli: Cli)(implicit log: Log) {
     conf        <- Layer.readFuryConf(layout)
     layer       <- Layer.retrieve(conf)
     cli         <- cli.hint(ImportNameArg)
+    cli         <- cli.hint(LayerVersionArg)
     cli         <- cli.hint(IgnoreArg)
     cli         <- cli.hint(ImportArg, Layer.pathCompletions().getOrElse(Nil))
     call        <- cli.call()
     layerName   <- call(ImportArg)
+    version     =  call(LayerVersionArg).toOption
     nameArg     <- cli.peek(ImportNameArg).orElse(layerName.suggestedName).ascribe(MissingParam(ImportNameArg))
     ignore      <- ~call(IgnoreArg).isSuccess
-    newLayerRef <- Layer.resolve(layerName)
+    newLayerRef <- Layer.resolve(layerName, version)
     pub         <- Layer.published(layerName)
     newLayer    <- Layer.get(newLayerRef, pub)
     _           <- newLayer.verify(ignore, false, Pointer.Root)

--- a/src/core/layer.scala
+++ b/src/core/layer.scala
@@ -259,9 +259,14 @@ object Layer extends Lens.Partial[Layer] {
       Success(None)
   }
 
-  def resolve(layerInput: LayerName)(implicit log: Log): Try[LayerRef] = layerInput match {
+  def resolve(layerInput: LayerName, version: Option[LayerVersion] = None)(implicit log: Log): Try[LayerRef] = layerInput match {
     case FileInput(path)       => ???
-    case FuryUri(domain, path) => Service.latest(domain, path, None).map { a => LayerRef(a.ref) }
+    case FuryUri(domain, path) =>
+      val artifact = version match {
+        case Some(v) => Service.fetch(domain, path, v)
+        case None => Service.latest(domain, path, None)
+      }
+      artifact.map { a => LayerRef(a.ref) }
     case IpfsRef(key)          => Success(LayerRef(key))
   }
 

--- a/src/core/tables.scala
+++ b/src/core/tables.scala
@@ -243,10 +243,16 @@ case class Tables() {
     Heading("Layers", _._2.map(_.layer: UserMsg).reduce { (l, r) => l+"\n"+r })
   )
   
-  val layerRefs: Tabulation[LayerProvenance] = Tabulation(
-    Heading("Import", _.ref),
-    Heading("IDs", _.ids),
-    Heading("Remotes", _.published),
-    Heading("Imported by", _.imports.keySet.map { v => v: UserMsg }.reduce { (l, r) => l+"\n"+r })
-  )
+  val layerRefs: Tabulation[LayerProvenance] = {
+    implicit val pointerOrdering = Ordering.Iterable[ImportId].on[Pointer](_.parts)
+    def sortedList[T : MsgShow : Ordering](entries: Iterable[T]): UserMsg =
+      entries.to[List].sorted.map { v => v: UserMsg }.reduce { (l, r) => l+"\n"+r }
+
+    Tabulation(
+      Heading("Import", _.ref),
+      Heading("IDs", _.ids),
+      Heading("Remotes", _.published),
+      Heading("Imported by", provenance => sortedList(provenance.imports.keySet))
+    )
+  }
 }

--- a/src/model/ids.scala
+++ b/src/model/ids.scala
@@ -333,7 +333,7 @@ case class ShortLayerRef(key: String) extends Key(msg"layer")
 
 case class LayerProvenance(ref: ShortLayerRef, imports: Map[Pointer, Import]) {
   def +(newImports: Map[Pointer, Import]) = copy(imports = imports ++ newImports)
-  def ids: Set[ImportId] = imports.values.map(_.id).to[Set]
+  def ids: SortedSet[ImportId] = SortedSet[ImportId]() ++ imports.values.map(_.id)
   def published: Set[PublishedLayer] = imports.values.flatMap(_.remote).to[Set]
 }
 
@@ -727,6 +727,7 @@ object ImportId {
   implicit val stringShow: StringShow[ImportId] = _.key
   implicit val diff: Diff[ImportId] = (l, r) => Diff.stringDiff.diff(l.key, r.key)
   implicit val parser: Parser[ImportId] = unapply(_)
+  implicit val ord: Ordering[ImportId] = Ordering[String].on[ImportId](_.key)
 
   def unapply(name: String): Option[ImportId] = name.only { case r"[a-z](-?[a-z0-9]+)*" => ImportId(name) }
 }

--- a/src/repo/universe.scala
+++ b/src/repo/universe.scala
@@ -97,7 +97,8 @@ case class UniverseCli(cli: Cli)(implicit val log: Log) extends CliApi {
     implicit val versionHints: LayerVersionArg.Hinter = LayerVersionArg.hint()
 
     def list: Try[ExitStatus] = (cli -< RawArg -< ColumnArg).action {
-      val output = (opt(ColumnArg), opt(LayerRefArg), universe >> (_.imports.values.to[List])) >> { case (col, layerRef, rows) =>
+      implicit val rowOrdering: Ordering[LayerProvenance] = Ordering[Iterable[ImportId]].on(_.ids)
+      val output = (opt(ColumnArg), opt(LayerRefArg), universe >> (_.imports.values.to[List].sorted)) >> { case (col, layerRef, rows) =>
         Tables().show(table, cli.cols, rows, has(RawArg), col, layerRef >> (_.key), "layer")
       }
       for {

--- a/test/passing/import-update/script
+++ b/test/passing/import-update/script
@@ -1,7 +1,7 @@
 fury layer init
 
 fury layer import -l fury://furore.dev/propensive/scala
-fury layer import -l fury://furore.dev/propensive/probably
+fury layer import -l fury://furore.dev/propensive/probably -V 2.2
 fury layer list --raw --column 'Published as'
 
 fury project add -n hello-test


### PR DESCRIPTION
Outstanding problems:
* The `--version` argument is allowed (and ignored) even when the import is referenced by its hash
* Some import hashes aren't present in the catalog
  * Sometimes migrating to a version present in the catalog yields an unexpected hash in the import list
  * This might be caused by migration of older layer versions
* The current `platform` layer contains two different references to `gastronomy`
  * Nevertheless, Fury is being built without conflict
  * Perhaps these two layers become identical after migration?
* It is impossible to get the full layer hash by its `ShortLayerRef`

This pull request s related to the issue #1291.