### PR TITLE
Use installed Fury to build Fury sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,8 @@ tmp/lib/fury.jar: $(wildcard src/**/*.scala) tmp/.version
 	 mkdir -p tmp/lib && \
 	 printf "$(MK) Done\n" && \
 	 printf "$(MK) Compiling Fury from source...\n" && \
-	 ./fury build save --https --project fury --module frontend --output linear --path tmp/lib --fat-jar --disable-security-manager && \
+	 ./fury && \
+	 ~/.local/share/fury/bin/fury build save --https --project fury --module frontend --output linear --path tmp/lib --fat-jar --disable-security-manager && \
 	 mv tmp/lib/fury-frontend.jar "$@" && \
 	 jar uf "$@" -C tmp .version && \
 	 touch "$@" && \


### PR DESCRIPTION
Looks like the launcher script from the bootstrapping distribution refuses to run any tasks except `system install` in a non-interactive shell.