### PR TITLE
Override FURY_HOME during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ tmp/lib/fury.jar: $(wildcard src/**/*.scala) tmp/.version
 	 printf "$(MK) Done\n" && \
 	 printf "$(MK) Compiling Fury from source...\n" && \
 	 ./fury && \
-	 ~/.local/share/fury/bin/fury build save --https --project fury --module frontend --output linear --path tmp/lib --fat-jar --disable-security-manager && \
+	 FURY_HOME="$(HOME)/.local/share/fury/usr/0.18.9" ~/.local/share/fury/bin/fury build save --https --project fury --module frontend --output linear --path tmp/lib --fat-jar --disable-security-manager && \
 	 mv tmp/lib/fury-frontend.jar "$@" && \
 	 jar uf "$@" -C tmp .version && \
 	 touch "$@" && \


### PR DESCRIPTION
Apparently the launcher script of the current bootstrapping version sets an incorrect value of `FURY_HOME`.