### PR TITLE
Improved CI configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,16 +1,14 @@
 name: Build
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
       fail-fast: false
-
     steps:
     - uses: actions/checkout@v2.0.0
     - run: git fetch --prune --unshallow
@@ -22,54 +20,101 @@ jobs:
           dist
           etc/launcher
         key: dist-${{ github.sha }}
+    - name: Install IPFS (Mac OS)
+      if: startsWith(matrix.os, 'macos')
+      run: brew install ipfs
+    - name: Install IPFS (Ubuntu)
+      if: startsWith(matrix.os, 'ubuntu')
+      run: sudo snap install ipfs
     - name: Run Makefile
       if: steps.cache-dist.outputs.cache-hit != 'true'
       run: |
         git describe --tags
-        make install
-      timeout-minutes: 10
-    - name: Install the pre-built distribution from cache
-      if: steps.cache-dist.outputs.cache-hit == 'true'
-      run: |
-        git describe --tags
         make tmp/.version
-        make --assume-old=dist/fury.tar.gz --assume-old=etc/launcher install
-      timeout-minutes: 3
-    - name: Package compilation logs
-      if: failure()
-      run: find ~/.cache/fury -type f -name '*.log' | tar cvzf compilation-logs.tar.gz --files-from -
-    - uses: actions/upload-artifact@v1.0.0
+        make dist/fury
+        mv dist/fury.tar.gz dist/fury-$(head -n 1 tmp/.version).tar.gz
+      timeout-minutes: 10
+    - uses: actions/upload-artifact@v2
+      with:
+        name: build-dist-${{ runner.os }}
+        path: dist
+    - uses: actions/upload-artifact@v2
       with:
         name: compilation-logs-${{ runner.os }}
-        path: compilation-logs.tar.gz
+        path: $HOME/.cache/fury/logs
       if: failure()
+
+  unit-tests:
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2.0.0
+    - uses: actions/download-artifact@v2
+      with:
+        name: build-dist-${{ runner.os }}
+        path: dist
+    - name: Install Fury
+      run: |
+        chmod +x dist/fury
+        mkdir -p "$HOME"/.local/share/fury/downloads
+        cp dist/fury-*.tar.gz "$HOME"/.local/share/fury/downloads
+        dist/fury system install
+        echo "::add-path::$HOME/.local/share/fury/usr/active/bin:$HOME/.local/share/fury/usr/active/opt"
+      timeout-minutes: 5
     - name: Run unit tests
       run: |
-        make -k test || touch unittests.failed
+        fury test --disable-security-manager --output linear || touch unittests.failed
         ! ls -1 unittests.failed 2> /dev/null
       timeout-minutes: 5
-    - name: Prepare environment for integration tests
-      run: |
-        git config --global user.name 'Github Actions'
-        git config --global user.email github.actions@propensive.com
-        echo "::add-path::$HOME/.local/share/fury/usr/$(head -n1 tmp/.version)/bin"
-      timeout-minutes: 1
-    - name: Run integration tests
-      run: |
-        etc/integration || touch integration.failed
-        ! ls -1 integration.failed 2> /dev/null
-      timeout-minutes: 15
-    - name: Package logs
-      if: failure()
-      run: find ~/.cache/fury -type f -name '*.log' | tar cvzf logs.tar.gz --files-from -
-    - uses: actions/upload-artifact@v1.0.0
+    - uses: actions/upload-artifact@v2
       with:
-        name: logs-${{ runner.os }}
-        path: logs.tar.gz
-      if: failure()
-    - name: Inspect cache
-      if: contains(runner.os, 'ubuntu')
-      run: du -h ~/.cache/fury --max-depth 2        
+        name: logs-unit-tests-${{ runner.os }}
+        path: ~/.cache/fury/logs
+      if: always()
     - name: Summary
       run: |
         ! ls -1 *.failed 2> /dev/null
+
+  integration-tests:
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2.0.0
+      - uses: actions/download-artifact@v2
+        with:
+          name: build-dist-${{ runner.os }}
+          path: dist
+      - name: Install Fury
+        run: |
+          chmod +x dist/fury
+          mkdir -p "$HOME"/.local/share/fury/downloads
+          cp dist/fury-*.tar.gz "$HOME"/.local/share/fury/downloads
+          dist/fury system install
+          echo "::add-path::$HOME/.local/share/fury/usr/active/bin:$HOME/.local/share/fury/usr/active/opt"
+        timeout-minutes: 5
+      - name: Prepare environment for integration tests
+        run: |
+          git config --global user.name 'Github Actions'
+          git config --global user.email github.actions@propensive.com
+        timeout-minutes: 1
+      - name: Run integration tests
+        run: |
+          etc/integration || touch integration.failed
+          ! ls -1 integration.failed 2> /dev/null
+        timeout-minutes: 15
+      - uses: actions/upload-artifact@v2
+        with:
+          name: logs-integration-${{ runner.os }}
+          path: ~/.cache/fury/logs
+        if: always()
+      - name: Summary
+        run: |
+          ! ls -1 *.failed 2> /dev/null

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ clean:
 
 uninstall:
 	@printf "$(MK) Removing all previous installations of Fury..."
-	@rm -rf $(HOME)/.local/share/fury/usr/$() $(HOME)/.local/share/fury/downloads && \
+	@rm -rf $(HOME)/.local/share/fury/downloads && \
 	 printf "done\n" || (printf "failed\n" && exit 1)
 
 install: etc/launcher dist/fury.tar.gz 
@@ -113,7 +113,7 @@ dist/fury: etc/launcher tmp/.bundle.ipfs
 	 mkdir -p dist && \
 	 sed -e "s/%VERSION%/$(VERSION)/" \
 	     -e "s/%HASH%/$(shell cat tmp/.bundle.ipfs)/" \
-	     -e "s/%MD5%/$(shell md5sum dist/fury.tar.gz | head -c 32)/" "$<" > "$@" && \
+	     -e "s/%MD5%/$(shell (md5sum dist/fury.tar.gz 2> /dev/null || md5 -r dist/fury.tar.gz 2> /dev/null) | head -c 32)/" "$<" > "$@" && \
 	 chmod +x "$@" && \
 	 printf "done\n" || (printf "failed\n" && exit 1)
 

--- a/etc/fury
+++ b/etc/fury
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$(uname -s)" = 'Linux' ]; then
+if command -v readlink > /dev/null && command -v realpath > /dev/null; then
   DEFAULT_FURY_HOME="$(realpath $(dirname "$(readlink -f "$0")")/..)"
 else
   DEFAULT_FURY_HOME="$(cd "$(dirname "$0")"/.. && pwd -P)"

--- a/etc/launcher
+++ b/etc/launcher
@@ -37,7 +37,7 @@ checkJava() {
 
 runFury() {
   printf "${info}Launching Fury ${version} in standalone mode...\n"
-  if [ -t 0 ]; then
+  if [[ -t 0 || ! -t 1 ]]; then
     FURY_HOME="${installDir}" "${installDir}/bin/fury" standalone ${args}
   else
     FURY_HOME="${installDir}" "${installDir}/bin/fury" standalone system install

--- a/src/core/install.scala
+++ b/src/core/install.scala
@@ -103,9 +103,8 @@ object Install {
     lines <- Try(scala.io.Source.fromFile(file.javaFile).getLines.filterNot(_.endsWith(furyTag))).recover {
                case e if(force || shell == getShell(env)) => List("")
              }
-
-    _     <- Success((Installation.rootBinDir / "fury").delete())
-    _     <- Try((Installation.binDir / "fury").symlinkTo(Installation.rootBinDir / "fury"))
+    _     <- Try(Installation.activeDir.delete())
+    _     <- Try(Installation.installDir.symlinkTo(Installation.activeDir))
     
     _     <- file.writeSync((lines.to[List] ++ setPathLine(List(Installation.rootBinDir,
                  Installation.optDir)) ++ extra).join("", "\n", "\n"))

--- a/src/model/layout.scala
+++ b/src/model/layout.scala
@@ -142,10 +142,10 @@ object Installation {
   val cache: Path = Xdg.cache("fury").extant()
   val config: Path = Xdg.config("fury").extant()
   val data: Path = Xdg.data("fury").extant()
-
-  val rootBinDir: Path = (data / "bin").extant()
-  val optDir: Path = (data / "opt").extant()
-  val completionsDir: Path = (data / "completions").extant()
+  val activeDir: Path = (data / "usr" / "active").extant()
+  val rootBinDir: Path = (activeDir / "bin").extant()
+  val optDir: Path = (activeDir / "opt").extant()
+  val completionsDir: Path = (activeDir / "completions").extant()
   val userConfig: Path = config / "config.fury"
   val aliasesPath: Path = config / "aliases"
   val policyFile: Path = config / "policy.conf"

--- a/test/passing/import-update/check
+++ b/test/passing/import-update/check
@@ -16,7 +16,12 @@ Set current module to app
 Checking out src/core from repository magnolia
 Cloning repository at gh:propensive/probably
 Checking out src/cli from repository probably
+Cloning repository at gh:propensive/mercator
 Checking out src/core from repository mercator
+Cloning repository at gh:propensive/escritoire
+Checking out src/core from repository escritoire
+Cloning repository at gh:propensive/gastronomy
+Checking out src/core from repository gastronomy
 Checking out src/core from repository probably
 Successfully compiled escritoire/core, gastronomy/core, magnolia/core, mercator/core, probably/cli, probably/core
 there was one feature warning; re-run with -feature for details
@@ -28,6 +33,10 @@ propensive/probably@1.10
 propensive/scala@1.2
 Fetching layer propensive/gastronomy@1.3 (ebkR6E4Y)
 Fetching layer propensive/magnolia@1.1 (V7gh7TiZ)
+Checking out src/core from repository magnolia
+Cloning repository at gh:propensive/probably
+Checking out src/cli from repository probably
+Checking out src/core from repository probably
 Successfully compiled escritoire/core, gastronomy/core, hello-test/app, magnolia/core, mercator/core, probably/cli, probably/core
 there were 17 feature warnings; re-run with -feature for details
 there was one feature warning; re-run with -feature for details


### PR DESCRIPTION
* Split the CI checks into three phases: compilation, unit tests, and integration tests
* Trigger CI only on pull request events
* Bumped actions/upload-artifact to version 2
* Use openssl to calculate MD5 hashes in the scripts
* Use readlink and realpath to find Fury's actual installation location if both commands are available
* Don't assume "system install" task if the output of the launcher script is consumed by a pipe
* Changed the structure of installation directories (same as in PR #1553)
* Changed the format of log archives