### PR TITLE
Update tutorial.md

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -3,7 +3,7 @@
 The easiest way to start a new Scala project with Fury is to clone an existing template. You can call your
 project anything you like, but for this tutorial we will call it `sample`. Start by running,
 ```
-fury layer clone -l propensive/scala-new -f sample
+fury layer clone -l propensive/scala -f sample
 cd sample
 ```
 


### PR DESCRIPTION
`scala-new` isn't an option currently in the list of layers. The options available that make the most sense to me are `scala3-new` and `scala`. I went with vanilla `scala` - if this is incorrect feel free to reject!